### PR TITLE
Move HTTP/gRPC metrics to OpenCensus

### DIFF
--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
+	"go.opencensus.io/plugin/ocgrpc"
 	monitoring "google.golang.org/genproto/googleapis/monitoring/v3"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/balancer/roundrobin"
@@ -103,10 +103,8 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 		grpc.WithBalancerName(roundrobin.Name),
 		grpc.WithBlock(), // Wait for the connection to be established before using it.
 		grpc.WithUserAgent(userAgent),
-		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
+		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
 	}
-	grpc_prometheus.EnableClientHandlingTimeHistogram()
-
 	if useAuth {
 		rpcCreds, err := oauth.NewApplicationDefault(context.Background(), MonitoringWriteScope)
 		if err != nil {

--- a/vendor/go.opencensus.io/LICENSE
+++ b/vendor/go.opencensus.io/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/go.opencensus.io/exporter/prometheus/prometheus.go
+++ b/vendor/go.opencensus.io/exporter/prometheus/prometheus.go
@@ -1,0 +1,325 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package prometheus contains a Prometheus exporter.
+//
+// Please note that this exporter is currently work in progress and not complete.
+package prometheus // import "go.opencensus.io/exporter/prometheus"
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"sync"
+
+	"go.opencensus.io/internal"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+// Exporter exports stats to Prometheus, users need
+// to register the exporter as an http.Handler to be
+// able to export.
+type Exporter struct {
+	opts    Options
+	g       prometheus.Gatherer
+	c       *collector
+	handler http.Handler
+}
+
+// Options contains options for configuring the exporter.
+type Options struct {
+	Namespace string
+	Registry  *prometheus.Registry
+	OnError   func(err error)
+}
+
+var (
+	newExporterOnce      sync.Once
+	errSingletonExporter = errors.New("expecting only one exporter per instance")
+)
+
+// NewExporter returns an exporter that exports stats to Prometheus.
+// Only one exporter should exist per instance
+func NewExporter(o Options) (*Exporter, error) {
+	var err = errSingletonExporter
+	var exporter *Exporter
+	newExporterOnce.Do(func() {
+		exporter, err = newExporter(o)
+	})
+	return exporter, err
+}
+
+func newExporter(o Options) (*Exporter, error) {
+	if o.Registry == nil {
+		o.Registry = prometheus.NewRegistry()
+	}
+	collector := newCollector(o, o.Registry)
+	e := &Exporter{
+		opts:    o,
+		g:       o.Registry,
+		c:       collector,
+		handler: promhttp.HandlerFor(o.Registry, promhttp.HandlerOpts{}),
+	}
+	return e, nil
+}
+
+var _ http.Handler = (*Exporter)(nil)
+var _ view.Exporter = (*Exporter)(nil)
+
+func (c *collector) registerViews(views ...*view.View) {
+	count := 0
+	for _, view := range views {
+		sig := viewSignature(c.opts.Namespace, view)
+		c.registeredViewsMu.Lock()
+		_, ok := c.registeredViews[sig]
+		c.registeredViewsMu.Unlock()
+
+		if !ok {
+			desc := prometheus.NewDesc(
+				viewName(c.opts.Namespace, view),
+				view.Description,
+				tagKeysToLabels(view.TagKeys),
+				nil,
+			)
+			c.registeredViewsMu.Lock()
+			c.registeredViews[sig] = desc
+			c.registeredViewsMu.Unlock()
+			count++
+		}
+	}
+	if count == 0 {
+		return
+	}
+
+	c.ensureRegisteredOnce()
+}
+
+// ensureRegisteredOnce invokes reg.Register on the collector itself
+// exactly once to ensure that we don't get errors such as
+//  cannot register the collector: descriptor Desc{fqName: *}
+//  already exists with the same fully-qualified name and const label values
+// which is documented by Prometheus at
+//  https://github.com/prometheus/client_golang/blob/fcc130e101e76c5d303513d0e28f4b6d732845c7/prometheus/registry.go#L89-L101
+func (c *collector) ensureRegisteredOnce() {
+	c.registerOnce.Do(func() {
+		if err := c.reg.Register(c); err != nil {
+			c.opts.onError(fmt.Errorf("cannot register the collector: %v", err))
+		}
+	})
+
+}
+
+func (o *Options) onError(err error) {
+	if o.OnError != nil {
+		o.OnError(err)
+	} else {
+		log.Printf("Failed to export to Prometheus: %v", err)
+	}
+}
+
+// ExportView exports to the Prometheus if view data has one or more rows.
+// Each OpenCensus AggregationData will be converted to
+// corresponding Prometheus Metric: SumData will be converted
+// to Untyped Metric, CountData will be a Counter Metric,
+// DistributionData will be a Histogram Metric.
+func (e *Exporter) ExportView(vd *view.Data) {
+	if len(vd.Rows) == 0 {
+		return
+	}
+	e.c.addViewData(vd)
+}
+
+// ServeHTTP serves the Prometheus endpoint.
+func (e *Exporter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	e.handler.ServeHTTP(w, r)
+}
+
+// collector implements prometheus.Collector
+type collector struct {
+	opts Options
+	mu   sync.Mutex // mu guards all the fields.
+
+	registerOnce sync.Once
+
+	// reg helps collector register views dynamically.
+	reg *prometheus.Registry
+
+	// viewData are accumulated and atomically
+	// appended to on every Export invocation, from
+	// stats. These views are cleared out when
+	// Collect is invoked and the cycle is repeated.
+	viewData map[string]*view.Data
+
+	registeredViewsMu sync.Mutex
+	// registeredViews maps a view to a prometheus desc.
+	registeredViews map[string]*prometheus.Desc
+}
+
+func (c *collector) addViewData(vd *view.Data) {
+	c.registerViews(vd.View)
+	sig := viewSignature(c.opts.Namespace, vd.View)
+
+	c.mu.Lock()
+	c.viewData[sig] = vd
+	c.mu.Unlock()
+}
+
+func (c *collector) Describe(ch chan<- *prometheus.Desc) {
+	c.registeredViewsMu.Lock()
+	registered := make(map[string]*prometheus.Desc)
+	for k, desc := range c.registeredViews {
+		registered[k] = desc
+	}
+	c.registeredViewsMu.Unlock()
+
+	for _, desc := range registered {
+		ch <- desc
+	}
+}
+
+// Collect fetches the statistics from OpenCensus
+// and delivers them as Prometheus Metrics.
+// Collect is invoked everytime a prometheus.Gatherer is run
+// for example when the HTTP endpoint is invoked by Prometheus.
+func (c *collector) Collect(ch chan<- prometheus.Metric) {
+	// We need a copy of all the view data up until this point.
+	viewData := c.cloneViewData()
+
+	for _, vd := range viewData {
+		sig := viewSignature(c.opts.Namespace, vd.View)
+		c.registeredViewsMu.Lock()
+		desc := c.registeredViews[sig]
+		c.registeredViewsMu.Unlock()
+
+		for _, row := range vd.Rows {
+			metric, err := c.toMetric(desc, vd.View, row)
+			if err != nil {
+				c.opts.onError(err)
+			} else {
+				ch <- metric
+			}
+		}
+	}
+
+}
+
+func (c *collector) toMetric(desc *prometheus.Desc, v *view.View, row *view.Row) (prometheus.Metric, error) {
+	switch data := row.Data.(type) {
+	case *view.CountData:
+		return prometheus.NewConstMetric(desc, prometheus.CounterValue, float64(data.Value), tagValues(row.Tags)...)
+
+	case *view.DistributionData:
+		points := make(map[float64]uint64)
+		// Histograms are cumulative in Prometheus.
+		// 1. Sort buckets in ascending order but, retain
+		// their indices for reverse lookup later on.
+		// TODO: If there is a guarantee that distribution elements
+		// are always sorted, then skip the sorting.
+		indicesMap := make(map[float64]int)
+		buckets := make([]float64, 0, len(v.Aggregation.Buckets))
+		for i, b := range v.Aggregation.Buckets {
+			if _, ok := indicesMap[b]; !ok {
+				indicesMap[b] = i
+				buckets = append(buckets, b)
+			}
+		}
+		sort.Float64s(buckets)
+
+		// 2. Now that the buckets are sorted by magnitude
+		// we can create cumulative indicesmap them back by reverse index
+		cumCount := uint64(0)
+		for _, b := range buckets {
+			i := indicesMap[b]
+			cumCount += uint64(data.CountPerBucket[i])
+			points[b] = cumCount
+		}
+		return prometheus.NewConstHistogram(desc, uint64(data.Count), data.Sum(), points, tagValues(row.Tags)...)
+
+	case *view.SumData:
+		return prometheus.NewConstMetric(desc, prometheus.UntypedValue, data.Value, tagValues(row.Tags)...)
+
+	case *view.LastValueData:
+		return prometheus.NewConstMetric(desc, prometheus.GaugeValue, data.Value, tagValues(row.Tags)...)
+
+	default:
+		return nil, fmt.Errorf("aggregation %T is not yet supported", v.Aggregation)
+	}
+}
+
+func tagKeysToLabels(keys []tag.Key) (labels []string) {
+	for _, key := range keys {
+		labels = append(labels, internal.Sanitize(key.Name()))
+	}
+	return labels
+}
+
+func tagsToLabels(tags []tag.Tag) []string {
+	var names []string
+	for _, tag := range tags {
+		names = append(names, internal.Sanitize(tag.Key.Name()))
+	}
+	return names
+}
+
+func newCollector(opts Options, registrar *prometheus.Registry) *collector {
+	return &collector{
+		reg:             registrar,
+		opts:            opts,
+		registeredViews: make(map[string]*prometheus.Desc),
+		viewData:        make(map[string]*view.Data),
+	}
+}
+
+func tagValues(t []tag.Tag) []string {
+	var values []string
+	for _, t := range t {
+		values = append(values, t.Value)
+	}
+	return values
+}
+
+func viewName(namespace string, v *view.View) string {
+	var name string
+	if namespace != "" {
+		name = namespace + "_"
+	}
+	return name + internal.Sanitize(v.Name)
+}
+
+func viewSignature(namespace string, v *view.View) string {
+	var buf bytes.Buffer
+	buf.WriteString(viewName(namespace, v))
+	for _, k := range v.TagKeys {
+		buf.WriteString("-" + k.Name())
+	}
+	return buf.String()
+}
+
+func (c *collector) cloneViewData() map[string]*view.Data {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	viewDataCopy := make(map[string]*view.Data)
+	for sig, viewData := range c.viewData {
+		viewDataCopy[sig] = viewData
+	}
+	return viewDataCopy
+}

--- a/vendor/go.opencensus.io/internal/internal.go
+++ b/vendor/go.opencensus.io/internal/internal.go
@@ -1,0 +1,32 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "go.opencensus.io/internal"
+
+import "time"
+
+// UserAgent is the user agent to be added to the outgoing
+// requests from the exporters.
+const UserAgent = "opencensus-go [0.12.0]"
+
+// MonotonicEndTime returns the end time at present
+// but offset from start, monotonically.
+//
+// The monotonic clock is used in subtractions hence
+// the duration since start added back to start gives
+// end as a monotonic time.
+// See https://golang.org/pkg/time/#hdr-Monotonic_Clocks
+func MonotonicEndTime(start time.Time) time.Time {
+	return start.Add(time.Now().Sub(start))
+}

--- a/vendor/go.opencensus.io/internal/sanitize.go
+++ b/vendor/go.opencensus.io/internal/sanitize.go
@@ -1,0 +1,50 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"strings"
+	"unicode"
+)
+
+const labelKeySizeLimit = 100
+
+// Sanitize returns a string that is trunacated to 100 characters if it's too
+// long, and replaces non-alphanumeric characters to underscores.
+func Sanitize(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	if len(s) > labelKeySizeLimit {
+		s = s[:labelKeySizeLimit]
+	}
+	s = strings.Map(sanitizeRune, s)
+	if unicode.IsDigit(rune(s[0])) {
+		s = "key_" + s
+	}
+	if s[0] == '_' {
+		s = "key" + s
+	}
+	return s
+}
+
+// converts anything that is not a letter or digit to an underscore
+func sanitizeRune(r rune) rune {
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return r
+	}
+	// Everything else turns into an underscore
+	return '_'
+}

--- a/vendor/go.opencensus.io/internal/tagencoding/tagencoding.go
+++ b/vendor/go.opencensus.io/internal/tagencoding/tagencoding.go
@@ -1,0 +1,72 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package tagencoding contains the tag encoding
+// used interally by the stats collector.
+package tagencoding // import "go.opencensus.io/internal/tagencoding"
+
+type Values struct {
+	Buffer     []byte
+	WriteIndex int
+	ReadIndex  int
+}
+
+func (vb *Values) growIfRequired(expected int) {
+	if len(vb.Buffer)-vb.WriteIndex < expected {
+		tmp := make([]byte, 2*(len(vb.Buffer)+1)+expected)
+		copy(tmp, vb.Buffer)
+		vb.Buffer = tmp
+	}
+}
+
+func (vb *Values) WriteValue(v []byte) {
+	length := len(v) & 0xff
+	vb.growIfRequired(1 + length)
+
+	// writing length of v
+	vb.Buffer[vb.WriteIndex] = byte(length)
+	vb.WriteIndex++
+
+	if length == 0 {
+		// No value was encoded for this key
+		return
+	}
+
+	// writing v
+	copy(vb.Buffer[vb.WriteIndex:], v[:length])
+	vb.WriteIndex += length
+}
+
+// ReadValue is the helper method to read the values when decoding valuesBytes to a map[Key][]byte.
+func (vb *Values) ReadValue() []byte {
+	// read length of v
+	length := int(vb.Buffer[vb.ReadIndex])
+	vb.ReadIndex++
+	if length == 0 {
+		// No value was encoded for this key
+		return nil
+	}
+
+	// read value of v
+	v := make([]byte, length)
+	endIdx := vb.ReadIndex + length
+	copy(v, vb.Buffer[vb.ReadIndex:endIdx])
+	vb.ReadIndex = endIdx
+	return v
+}
+
+func (vb *Values) Bytes() []byte {
+	return vb.Buffer[:vb.WriteIndex]
+}

--- a/vendor/go.opencensus.io/internal/traceinternals.go
+++ b/vendor/go.opencensus.io/internal/traceinternals.go
@@ -1,0 +1,52 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"time"
+)
+
+// Trace allows internal access to some trace functionality.
+// TODO(#412): remove this
+var Trace interface{}
+
+var LocalSpanStoreEnabled bool
+
+// BucketConfiguration stores the number of samples to store for span buckets
+// for successful and failed spans for a particular span name.
+type BucketConfiguration struct {
+	Name                 string
+	MaxRequestsSucceeded int
+	MaxRequestsErrors    int
+}
+
+// PerMethodSummary is a summary of the spans stored for a single span name.
+type PerMethodSummary struct {
+	Active         int
+	LatencyBuckets []LatencyBucketSummary
+	ErrorBuckets   []ErrorBucketSummary
+}
+
+// LatencyBucketSummary is a summary of a latency bucket.
+type LatencyBucketSummary struct {
+	MinLatency, MaxLatency time.Duration
+	Size                   int
+}
+
+// ErrorBucketSummary is a summary of an error bucket.
+type ErrorBucketSummary struct {
+	ErrorCode int32
+	Size      int
+}

--- a/vendor/go.opencensus.io/plugin/ocgrpc/client.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/client.go
@@ -1,0 +1,55 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocgrpc
+
+import (
+	"go.opencensus.io/trace"
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc/stats"
+)
+
+// ClientHandler implements a gRPC stats.Handler for recording OpenCensus stats and
+// traces. Use with gRPC clients only.
+type ClientHandler struct {
+	// StartOptions allows configuring the StartOptions used to create new spans.
+	//
+	// StartOptions.SpanKind will always be set to trace.SpanKindClient
+	// for spans started by this handler.
+	StartOptions trace.StartOptions
+}
+
+func (c *ClientHandler) HandleConn(ctx context.Context, cs stats.ConnStats) {
+	// no-op
+}
+
+// TagConn exists to satisfy gRPC stats.Handler.
+func (c *ClientHandler) TagConn(ctx context.Context, cti *stats.ConnTagInfo) context.Context {
+	// no-op
+	return ctx
+}
+
+// HandleRPC implements per-RPC tracing and stats instrumentation.
+func (c *ClientHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	traceHandleRPC(ctx, rs)
+	statsHandleRPC(ctx, rs)
+}
+
+// TagRPC implements per-RPC context management.
+func (c *ClientHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	ctx = c.traceTagRPC(ctx, rti)
+	ctx = c.statsTagRPC(ctx, rti)
+	return ctx
+}

--- a/vendor/go.opencensus.io/plugin/ocgrpc/client_metrics.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/client_metrics.go
@@ -1,0 +1,116 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ocgrpc
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// The following variables are measures are recorded by ClientHandler:
+var (
+	ClientSentMessagesPerRPC     = stats.Int64("grpc.io/client/sent_messages_per_rpc", "Number of messages sent in the RPC (always 1 for non-streaming RPCs).", stats.UnitDimensionless)
+	ClientSentBytesPerRPC        = stats.Int64("grpc.io/client/sent_bytes_per_rpc", "Total bytes sent across all request messages per RPC.", stats.UnitBytes)
+	ClientReceivedMessagesPerRPC = stats.Int64("grpc.io/client/received_messages_per_rpc", "Number of response messages received per RPC (always 1 for non-streaming RPCs).", stats.UnitDimensionless)
+	ClientReceivedBytesPerRPC    = stats.Int64("grpc.io/client/received_bytes_per_rpc", "Total bytes received across all response messages per RPC.", stats.UnitBytes)
+	ClientRoundtripLatency       = stats.Float64("grpc.io/client/roundtrip_latency", "Time between first byte of request sent to last byte of response received, or terminal error.", stats.UnitMilliseconds)
+	ClientServerLatency          = stats.Float64("grpc.io/client/server_latency", `Propagated from the server and should have the same value as "grpc.io/server/latency".`, stats.UnitMilliseconds)
+)
+
+// Predefined views may be subscribed to collect data for the above measures.
+// As always, you may also define your own custom views over measures collected by this
+// package. These are declared as a convenience only; none are subscribed by
+// default.
+var (
+	ClientSentBytesPerRPCView = &view.View{
+		Measure:     ClientSentBytesPerRPC,
+		Name:        "grpc.io/client/sent_bytes_per_rpc",
+		Description: "Distribution of bytes sent per RPC, by method.",
+		TagKeys:     []tag.Key{KeyClientMethod},
+		Aggregation: DefaultBytesDistribution,
+	}
+
+	ClientReceivedBytesPerRPCView = &view.View{
+		Measure:     ClientReceivedBytesPerRPC,
+		Name:        "grpc.io/client/received_bytes_per_rpc",
+		Description: "Distribution of bytes received per RPC, by method.",
+		TagKeys:     []tag.Key{KeyClientMethod},
+		Aggregation: DefaultBytesDistribution,
+	}
+
+	ClientRoundtripLatencyView = &view.View{
+		Measure:     ClientRoundtripLatency,
+		Name:        "grpc.io/client/roundtrip_latency",
+		Description: "Distribution of round-trip latency, by method.",
+		TagKeys:     []tag.Key{KeyClientMethod},
+		Aggregation: DefaultMillisecondsDistribution,
+	}
+
+	ClientCompletedRPCsView = &view.View{
+		Measure:     ClientRoundtripLatency,
+		Name:        "grpc.io/client/completed_rpcs",
+		Description: "Count of RPCs by method and status.",
+		TagKeys:     []tag.Key{KeyClientMethod, KeyClientStatus},
+		Aggregation: view.Count(),
+	}
+
+	ClientSentMessagesPerRPCView = &view.View{
+		Measure:     ClientSentMessagesPerRPC,
+		Name:        "grpc.io/client/sent_messages_per_rpc",
+		Description: "Distribution of sent messages count per RPC, by method.",
+		TagKeys:     []tag.Key{KeyClientMethod},
+		Aggregation: DefaultMessageCountDistribution,
+	}
+
+	ClientReceivedMessagesPerRPCView = &view.View{
+		Measure:     ClientReceivedMessagesPerRPC,
+		Name:        "grpc.io/client/received_messages_per_rpc",
+		Description: "Distribution of received messages count per RPC, by method.",
+		TagKeys:     []tag.Key{KeyClientMethod},
+		Aggregation: DefaultMessageCountDistribution,
+	}
+
+	ClientServerLatencyView = &view.View{
+		Measure:     ClientServerLatency,
+		Name:        "grpc.io/client/server_latency",
+		Description: "Distribution of server latency as viewed by client, by method.",
+		TagKeys:     []tag.Key{KeyClientMethod},
+		Aggregation: DefaultMillisecondsDistribution,
+	}
+
+	// Deprecated: This view is going to be removed, if you need it please define it
+	// yourself.
+	ClientRequestCountView = &view.View{
+		Name:        "Count of request messages per client RPC",
+		TagKeys:     []tag.Key{KeyClientMethod},
+		Measure:     ClientRoundtripLatency,
+		Aggregation: view.Count(),
+	}
+)
+
+// DefaultClientViews are the default client views provided by this package.
+var DefaultClientViews = []*view.View{
+	ClientSentBytesPerRPCView,
+	ClientReceivedBytesPerRPCView,
+	ClientRoundtripLatencyView,
+	ClientCompletedRPCsView,
+}
+
+// TODO(jbd): Add roundtrip_latency, uncompressed_request_bytes, uncompressed_response_bytes, request_count, response_count.
+// TODO(acetechnologist): This is temporary and will need to be replaced by a
+// mechanism to load these defaults from a common repository/config shared by
+// all supported languages. Likely a serialized protobuf of these defaults.

--- a/vendor/go.opencensus.io/plugin/ocgrpc/client_stats_handler.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/client_stats_handler.go
@@ -1,0 +1,49 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ocgrpc
+
+import (
+	"time"
+
+	"go.opencensus.io/tag"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/stats"
+)
+
+// statsTagRPC gets the tag.Map populated by the application code, serializes
+// its tags into the GRPC metadata in order to be sent to the server.
+func (h *ClientHandler) statsTagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	startTime := time.Now()
+	if info == nil {
+		if grpclog.V(2) {
+			grpclog.Infof("clientHandler.TagRPC called with nil info.", info.FullMethodName)
+		}
+		return ctx
+	}
+
+	d := &rpcData{
+		startTime: startTime,
+		method:    info.FullMethodName,
+	}
+	ts := tag.FromContext(ctx)
+	if ts != nil {
+		encoded := tag.Encode(ts)
+		ctx = stats.SetTags(ctx, encoded)
+	}
+
+	return context.WithValue(ctx, rpcDataKey, d)
+}

--- a/vendor/go.opencensus.io/plugin/ocgrpc/doc.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ocgrpc contains OpenCensus stats and trace
+// integrations for gRPC.
+//
+// Use ServerHandler for servers and ClientHandler for clients.
+package ocgrpc // import "go.opencensus.io/plugin/ocgrpc"

--- a/vendor/go.opencensus.io/plugin/ocgrpc/server.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/server.go
@@ -1,0 +1,80 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocgrpc
+
+import (
+	"go.opencensus.io/trace"
+	"golang.org/x/net/context"
+
+	"google.golang.org/grpc/stats"
+)
+
+// ServerHandler implements gRPC stats.Handler recording OpenCensus stats and
+// traces. Use with gRPC servers.
+//
+// When installed (see Example), tracing metadata is read from inbound RPCs
+// by default. If no tracing metadata is present, or if the tracing metadata is
+// present but the SpanContext isn't sampled, then a new trace may be started
+// (as determined by Sampler).
+type ServerHandler struct {
+	// IsPublicEndpoint may be set to true to always start a new trace around
+	// each RPC. Any SpanContext in the RPC metadata will be added as a linked
+	// span instead of making it the parent of the span created around the
+	// server RPC.
+	//
+	// Be aware that if you leave this false (the default) on a public-facing
+	// server, callers will be able to send tracing metadata in gRPC headers
+	// and trigger traces in your backend.
+	IsPublicEndpoint bool
+
+	// StartOptions to use for to spans started around RPCs handled by this server.
+	//
+	// These will apply even if there is tracing metadata already
+	// present on the inbound RPC but the SpanContext is not sampled. This
+	// ensures that each service has some opportunity to be traced. If you would
+	// like to not add any additional traces for this gRPC service, set:
+	//
+	//   StartOptions.Sampler = trace.ProbabilitySampler(0.0)
+	//
+	// StartOptions.SpanKind will always be set to trace.SpanKindServer
+	// for spans started by this handler.
+	StartOptions trace.StartOptions
+}
+
+var _ stats.Handler = (*ServerHandler)(nil)
+
+// HandleConn exists to satisfy gRPC stats.Handler.
+func (s *ServerHandler) HandleConn(ctx context.Context, cs stats.ConnStats) {
+	// no-op
+}
+
+// TagConn exists to satisfy gRPC stats.Handler.
+func (s *ServerHandler) TagConn(ctx context.Context, cti *stats.ConnTagInfo) context.Context {
+	// no-op
+	return ctx
+}
+
+// HandleRPC implements per-RPC tracing and stats instrumentation.
+func (s *ServerHandler) HandleRPC(ctx context.Context, rs stats.RPCStats) {
+	traceHandleRPC(ctx, rs)
+	statsHandleRPC(ctx, rs)
+}
+
+// TagRPC implements per-RPC context management.
+func (s *ServerHandler) TagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	ctx = s.traceTagRPC(ctx, rti)
+	ctx = s.statsTagRPC(ctx, rti)
+	return ctx
+}

--- a/vendor/go.opencensus.io/plugin/ocgrpc/server_metrics.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/server_metrics.go
@@ -1,0 +1,97 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ocgrpc
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// The following variables are measures are recorded by ServerHandler:
+var (
+	ServerReceivedMessagesPerRPC = stats.Int64("grpc.io/server/received_messages_per_rpc", "Number of messages received in each RPC. Has value 1 for non-streaming RPCs.", stats.UnitDimensionless)
+	ServerReceivedBytesPerRPC    = stats.Int64("grpc.io/server/received_bytes_per_rpc", "Total bytes received across all messages per RPC.", stats.UnitBytes)
+	ServerSentMessagesPerRPC     = stats.Int64("grpc.io/server/sent_messages_per_rpc", "Number of messages sent in each RPC. Has value 1 for non-streaming RPCs.", stats.UnitDimensionless)
+	ServerSentBytesPerRPC        = stats.Int64("grpc.io/server/sent_bytes_per_rpc", "Total bytes sent in across all response messages per RPC.", stats.UnitBytes)
+	ServerLatency                = stats.Float64("grpc.io/server/server_latency", "Time between first byte of request received to last byte of response sent, or terminal error.", stats.UnitMilliseconds)
+)
+
+// TODO(acetechnologist): This is temporary and will need to be replaced by a
+// mechanism to load these defaults from a common repository/config shared by
+// all supported languages. Likely a serialized protobuf of these defaults.
+
+// Predefined views may be subscribed to collect data for the above measures.
+// As always, you may also define your own custom views over measures collected by this
+// package. These are declared as a convenience only; none are subscribed by
+// default.
+var (
+	ServerReceivedBytesPerRPCView = &view.View{
+		Name:        "grpc.io/server/received_bytes_per_rpc",
+		Description: "Distribution of received bytes per RPC, by method.",
+		Measure:     ServerReceivedBytesPerRPC,
+		TagKeys:     []tag.Key{KeyServerMethod},
+		Aggregation: DefaultBytesDistribution,
+	}
+
+	ServerSentBytesPerRPCView = &view.View{
+		Name:        "grpc.io/server/sent_bytes_per_rpc",
+		Description: "Distribution of total sent bytes per RPC, by method.",
+		Measure:     ServerSentBytesPerRPC,
+		TagKeys:     []tag.Key{KeyServerMethod},
+		Aggregation: DefaultBytesDistribution,
+	}
+
+	ServerLatencyView = &view.View{
+		Name:        "grpc.io/server/server_latency",
+		Description: "Distribution of server latency in milliseconds, by method.",
+		TagKeys:     []tag.Key{KeyServerMethod},
+		Measure:     ServerLatency,
+		Aggregation: DefaultMillisecondsDistribution,
+	}
+
+	ServerCompletedRPCsView = &view.View{
+		Name:        "grpc.io/server/completed_rpcs",
+		Description: "Count of RPCs by method and status.",
+		TagKeys:     []tag.Key{KeyServerMethod, KeyServerStatus},
+		Measure:     ServerLatency,
+		Aggregation: view.Count(),
+	}
+
+	ServerReceivedMessagesPerRPCView = &view.View{
+		Name:        "grpc.io/server/received_messages_per_rpc",
+		Description: "Distribution of messages received count per RPC, by method.",
+		TagKeys:     []tag.Key{KeyServerMethod},
+		Measure:     ServerReceivedMessagesPerRPC,
+		Aggregation: DefaultMessageCountDistribution,
+	}
+
+	ServerSentMessagesPerRPCView = &view.View{
+		Name:        "grpc.io/server/sent_messages_per_rpc",
+		Description: "Distribution of messages sent count per RPC, by method.",
+		TagKeys:     []tag.Key{KeyServerMethod},
+		Measure:     ServerSentMessagesPerRPC,
+		Aggregation: DefaultMessageCountDistribution,
+	}
+)
+
+// DefaultServerViews are the default server views provided by this package.
+var DefaultServerViews = []*view.View{
+	ServerReceivedBytesPerRPCView,
+	ServerSentBytesPerRPCView,
+	ServerLatencyView,
+	ServerCompletedRPCsView,
+}

--- a/vendor/go.opencensus.io/plugin/ocgrpc/server_stats_handler.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/server_stats_handler.go
@@ -1,0 +1,63 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ocgrpc
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+
+	"go.opencensus.io/tag"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/stats"
+)
+
+// statsTagRPC gets the metadata from gRPC context, extracts the encoded tags from
+// it and creates a new tag.Map and puts them into the returned context.
+func (h *ServerHandler) statsTagRPC(ctx context.Context, info *stats.RPCTagInfo) context.Context {
+	startTime := time.Now()
+	if info == nil {
+		if grpclog.V(2) {
+			grpclog.Infof("opencensus: TagRPC called with nil info.")
+		}
+		return ctx
+	}
+	d := &rpcData{
+		startTime: startTime,
+		method:    info.FullMethodName,
+	}
+	propagated := h.extractPropagatedTags(ctx)
+	ctx = tag.NewContext(ctx, propagated)
+	ctx, _ = tag.New(ctx, tag.Upsert(KeyServerMethod, methodName(info.FullMethodName)))
+	return context.WithValue(ctx, rpcDataKey, d)
+}
+
+// extractPropagatedTags creates a new tag map containing the tags extracted from the
+// gRPC metadata.
+func (h *ServerHandler) extractPropagatedTags(ctx context.Context) *tag.Map {
+	buf := stats.Tags(ctx)
+	if buf == nil {
+		return nil
+	}
+	propagated, err := tag.Decode(buf)
+	if err != nil {
+		if grpclog.V(2) {
+			grpclog.Warningf("opencensus: Failed to decode tags from gRPC metadata failed to decode: %v", err)
+		}
+		return nil
+	}
+	return propagated
+}

--- a/vendor/go.opencensus.io/plugin/ocgrpc/stats_common.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/stats_common.go
@@ -1,0 +1,199 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package ocgrpc
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	ocstats "go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
+)
+
+type grpcInstrumentationKey string
+
+// rpcData holds the instrumentation RPC data that is needed between the start
+// and end of an call. It holds the info that this package needs to keep track
+// of between the various GRPC events.
+type rpcData struct {
+	// reqCount and respCount has to be the first words
+	// in order to be 64-aligned on 32-bit architectures.
+	sentCount, sentBytes, recvCount, recvBytes int64 // access atomically
+
+	// startTime represents the time at which TagRPC was invoked at the
+	// beginning of an RPC. It is an appoximation of the time when the
+	// application code invoked GRPC code.
+	startTime time.Time
+	method    string
+}
+
+// The following variables define the default hard-coded auxiliary data used by
+// both the default GRPC client and GRPC server metrics.
+var (
+	DefaultBytesDistribution        = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
+	DefaultMillisecondsDistribution = view.Distribution(0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+	DefaultMessageCountDistribution = view.Distribution(0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536)
+)
+
+var (
+	KeyServerMethod, _ = tag.NewKey("grpc_server_method")
+	KeyClientMethod, _ = tag.NewKey("grpc_client_method")
+	KeyServerStatus, _ = tag.NewKey("grpc_server_status")
+	KeyClientStatus, _ = tag.NewKey("grpc_client_status")
+)
+
+var (
+	rpcDataKey = grpcInstrumentationKey("opencensus-rpcData")
+)
+
+func methodName(fullname string) string {
+	return strings.TrimLeft(fullname, "/")
+}
+
+// statsHandleRPC processes the RPC events.
+func statsHandleRPC(ctx context.Context, s stats.RPCStats) {
+	switch st := s.(type) {
+	case *stats.Begin, *stats.OutHeader, *stats.InHeader, *stats.InTrailer, *stats.OutTrailer:
+		// do nothing for client
+	case *stats.OutPayload:
+		handleRPCOutPayload(ctx, st)
+	case *stats.InPayload:
+		handleRPCInPayload(ctx, st)
+	case *stats.End:
+		handleRPCEnd(ctx, st)
+	default:
+		grpclog.Infof("unexpected stats: %T", st)
+	}
+}
+
+func handleRPCOutPayload(ctx context.Context, s *stats.OutPayload) {
+	d, ok := ctx.Value(rpcDataKey).(*rpcData)
+	if !ok {
+		if grpclog.V(2) {
+			grpclog.Infoln("Failed to retrieve *rpcData from context.")
+		}
+		return
+	}
+
+	atomic.AddInt64(&d.sentBytes, int64(s.Length))
+	atomic.AddInt64(&d.sentCount, 1)
+}
+
+func handleRPCInPayload(ctx context.Context, s *stats.InPayload) {
+	d, ok := ctx.Value(rpcDataKey).(*rpcData)
+	if !ok {
+		if grpclog.V(2) {
+			grpclog.Infoln("Failed to retrieve *rpcData from context.")
+		}
+		return
+	}
+
+	atomic.AddInt64(&d.recvBytes, int64(s.Length))
+	atomic.AddInt64(&d.recvCount, 1)
+}
+
+func handleRPCEnd(ctx context.Context, s *stats.End) {
+	d, ok := ctx.Value(rpcDataKey).(*rpcData)
+	if !ok {
+		if grpclog.V(2) {
+			grpclog.Infoln("Failed to retrieve *rpcData from context.")
+		}
+		return
+	}
+
+	elapsedTime := time.Since(d.startTime)
+
+	var st string
+	if s.Error != nil {
+		s, ok := status.FromError(s.Error)
+		if ok {
+			st = statusCodeToString(s)
+		}
+	} else {
+		st = "OK"
+	}
+
+	latencyMillis := float64(elapsedTime) / float64(time.Millisecond)
+	if s.Client {
+		ctx, _ = tag.New(ctx,
+			tag.Upsert(KeyClientMethod, methodName(d.method)),
+			tag.Upsert(KeyClientStatus, st))
+		ocstats.Record(ctx,
+			ClientSentBytesPerRPC.M(atomic.LoadInt64(&d.sentBytes)),
+			ClientSentMessagesPerRPC.M(atomic.LoadInt64(&d.sentCount)),
+			ClientReceivedMessagesPerRPC.M(atomic.LoadInt64(&d.recvCount)),
+			ClientReceivedBytesPerRPC.M(atomic.LoadInt64(&d.recvBytes)),
+			ClientRoundtripLatency.M(latencyMillis))
+	} else {
+		ctx, _ = tag.New(ctx, tag.Upsert(KeyServerStatus, st))
+		ocstats.Record(ctx,
+			ServerSentBytesPerRPC.M(atomic.LoadInt64(&d.sentBytes)),
+			ServerSentMessagesPerRPC.M(atomic.LoadInt64(&d.sentCount)),
+			ServerReceivedMessagesPerRPC.M(atomic.LoadInt64(&d.recvCount)),
+			ServerReceivedBytesPerRPC.M(atomic.LoadInt64(&d.recvBytes)),
+			ServerLatency.M(latencyMillis))
+	}
+}
+
+func statusCodeToString(s *status.Status) string {
+	// see https://github.com/grpc/grpc/blob/master/doc/statuscodes.md
+	switch c := s.Code(); c {
+	case codes.OK:
+		return "OK"
+	case codes.Canceled:
+		return "CANCELLED"
+	case codes.Unknown:
+		return "UNKNOWN"
+	case codes.InvalidArgument:
+		return "INVALID_ARGUMENT"
+	case codes.DeadlineExceeded:
+		return "DEADLINE_EXCEEDED"
+	case codes.NotFound:
+		return "NOT_FOUND"
+	case codes.AlreadyExists:
+		return "ALREADY_EXISTS"
+	case codes.PermissionDenied:
+		return "PERMISSION_DENIED"
+	case codes.ResourceExhausted:
+		return "RESOURCE_EXHAUSTED"
+	case codes.FailedPrecondition:
+		return "FAILED_PRECONDITION"
+	case codes.Aborted:
+		return "ABORTED"
+	case codes.OutOfRange:
+		return "OUT_OF_RANGE"
+	case codes.Unimplemented:
+		return "UNIMPLEMENTED"
+	case codes.Internal:
+		return "INTERNAL"
+	case codes.Unavailable:
+		return "UNAVAILABLE"
+	case codes.DataLoss:
+		return "DATA_LOSS"
+	case codes.Unauthenticated:
+		return "UNAUTHENTICATED"
+	default:
+		return "CODE_" + strconv.FormatInt(int64(c), 10)
+	}
+}

--- a/vendor/go.opencensus.io/plugin/ocgrpc/trace_common.go
+++ b/vendor/go.opencensus.io/plugin/ocgrpc/trace_common.go
@@ -1,0 +1,107 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ocgrpc
+
+import (
+	"strings"
+
+	"google.golang.org/grpc/codes"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/stats"
+	"google.golang.org/grpc/status"
+)
+
+const traceContextKey = "grpc-trace-bin"
+
+// TagRPC creates a new trace span for the client side of the RPC.
+//
+// It returns ctx with the new trace span added and a serialization of the
+// SpanContext added to the outgoing gRPC metadata.
+func (c *ClientHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	name := strings.TrimPrefix(rti.FullMethodName, "/")
+	name = strings.Replace(name, "/", ".", -1)
+	ctx, span := trace.StartSpan(ctx, name,
+		trace.WithSampler(c.StartOptions.Sampler),
+		trace.WithSpanKind(trace.SpanKindClient)) // span is ended by traceHandleRPC
+	traceContextBinary := propagation.Binary(span.SpanContext())
+	return metadata.AppendToOutgoingContext(ctx, traceContextKey, string(traceContextBinary))
+}
+
+// TagRPC creates a new trace span for the server side of the RPC.
+//
+// It checks the incoming gRPC metadata in ctx for a SpanContext, and if
+// it finds one, uses that SpanContext as the parent context of the new span.
+//
+// It returns ctx, with the new trace span added.
+func (s *ServerHandler) traceTagRPC(ctx context.Context, rti *stats.RPCTagInfo) context.Context {
+	md, _ := metadata.FromIncomingContext(ctx)
+	name := strings.TrimPrefix(rti.FullMethodName, "/")
+	name = strings.Replace(name, "/", ".", -1)
+	traceContext := md[traceContextKey]
+	var (
+		parent     trace.SpanContext
+		haveParent bool
+	)
+	if len(traceContext) > 0 {
+		// Metadata with keys ending in -bin are actually binary. They are base64
+		// encoded before being put on the wire, see:
+		// https://github.com/grpc/grpc-go/blob/08d6261/Documentation/grpc-metadata.md#storing-binary-data-in-metadata
+		traceContextBinary := []byte(traceContext[0])
+		parent, haveParent = propagation.FromBinary(traceContextBinary)
+		if haveParent && !s.IsPublicEndpoint {
+			ctx, _ := trace.StartSpanWithRemoteParent(ctx, name, parent,
+				trace.WithSpanKind(trace.SpanKindServer),
+				trace.WithSampler(s.StartOptions.Sampler),
+			)
+			return ctx
+		}
+	}
+	ctx, span := trace.StartSpan(ctx, name,
+		trace.WithSpanKind(trace.SpanKindServer),
+		trace.WithSampler(s.StartOptions.Sampler))
+	if haveParent {
+		span.AddLink(trace.Link{TraceID: parent.TraceID, SpanID: parent.SpanID, Type: trace.LinkTypeChild})
+	}
+	return ctx
+}
+
+func traceHandleRPC(ctx context.Context, rs stats.RPCStats) {
+	span := trace.FromContext(ctx)
+	// TODO: compressed and uncompressed sizes are not populated in every message.
+	switch rs := rs.(type) {
+	case *stats.Begin:
+		span.AddAttributes(
+			trace.BoolAttribute("Client", rs.Client),
+			trace.BoolAttribute("FailFast", rs.FailFast))
+	case *stats.InPayload:
+		span.AddMessageReceiveEvent(0 /* TODO: messageID */, int64(rs.Length), int64(rs.WireLength))
+	case *stats.OutPayload:
+		span.AddMessageSendEvent(0, int64(rs.Length), int64(rs.WireLength))
+	case *stats.End:
+		if rs.Error != nil {
+			s, ok := status.FromError(rs.Error)
+			if ok {
+				span.SetStatus(trace.Status{Code: int32(s.Code()), Message: s.Message()})
+			} else {
+				span.SetStatus(trace.Status{Code: int32(codes.Internal), Message: rs.Error.Error()})
+			}
+		}
+		span.End()
+	}
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/client.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/client.go
@@ -1,0 +1,84 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// Transport is an http.RoundTripper that instruments all outgoing requests with
+// stats and tracing. The zero value is intended to be a useful default, but for
+// now it's recommended that you explicitly set Propagation.
+type Transport struct {
+	// Base may be set to wrap another http.RoundTripper that does the actual
+	// requests. By default http.DefaultTransport is used.
+	//
+	// If base HTTP roundtripper implements CancelRequest,
+	// the returned round tripper will be cancelable.
+	Base http.RoundTripper
+
+	// Propagation defines how traces are propagated. If unspecified, a default
+	// (currently B3 format) will be used.
+	Propagation propagation.HTTPFormat
+
+	// StartOptions are applied to the span started by this Transport around each
+	// request.
+	//
+	// StartOptions.SpanKind will always be set to trace.SpanKindClient
+	// for spans started by this transport.
+	StartOptions trace.StartOptions
+
+	// TODO: Implement tag propagation for HTTP.
+}
+
+// RoundTrip implements http.RoundTripper, delegating to Base and recording stats and traces for the request.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt := t.base()
+	// TODO: remove excessive nesting of http.RoundTrippers here.
+	format := t.Propagation
+	if format == nil {
+		format = defaultFormat
+	}
+	rt = &traceTransport{
+		base:   rt,
+		format: format,
+		startOptions: trace.StartOptions{
+			Sampler:  t.StartOptions.Sampler,
+			SpanKind: trace.SpanKindClient,
+		},
+	}
+	rt = statsTransport{base: rt}
+	return rt.RoundTrip(req)
+}
+
+func (t *Transport) base() http.RoundTripper {
+	if t.Base != nil {
+		return t.Base
+	}
+	return http.DefaultTransport
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *Transport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base().(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/client_stats.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/client_stats.go
@@ -1,0 +1,125 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+)
+
+// statsTransport is an http.RoundTripper that collects stats for the outgoing requests.
+type statsTransport struct {
+	base http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper, delegating to Base and recording stats for the request.
+func (t statsTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx, _ := tag.New(req.Context(),
+		tag.Upsert(Host, req.URL.Host),
+		tag.Upsert(Path, req.URL.Path),
+		tag.Upsert(Method, req.Method))
+	req = req.WithContext(ctx)
+	track := &tracker{
+		start: time.Now(),
+		ctx:   ctx,
+	}
+	if req.Body == nil {
+		// TODO: Handle cases where ContentLength is not set.
+		track.reqSize = -1
+	} else if req.ContentLength > 0 {
+		track.reqSize = req.ContentLength
+	}
+	stats.Record(ctx, ClientRequestCount.M(1))
+
+	// Perform request.
+	resp, err := t.base.RoundTrip(req)
+
+	if err != nil {
+		track.statusCode = http.StatusInternalServerError
+		track.end()
+	} else {
+		track.statusCode = resp.StatusCode
+		if resp.Body == nil {
+			track.end()
+		} else {
+			track.body = resp.Body
+			resp.Body = track
+		}
+	}
+	return resp, err
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t statsTransport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base.(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}
+
+type tracker struct {
+	ctx        context.Context
+	respSize   int64
+	reqSize    int64
+	start      time.Time
+	body       io.ReadCloser
+	statusCode int
+	endOnce    sync.Once
+}
+
+var _ io.ReadCloser = (*tracker)(nil)
+
+func (t *tracker) end() {
+	t.endOnce.Do(func() {
+		m := []stats.Measurement{
+			ClientLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
+			ClientResponseBytes.M(t.respSize),
+		}
+		if t.reqSize >= 0 {
+			m = append(m, ClientRequestBytes.M(t.reqSize))
+		}
+		ctx, _ := tag.New(t.ctx, tag.Upsert(StatusCode, strconv.Itoa(t.statusCode)))
+		stats.Record(ctx, m...)
+	})
+}
+
+func (t *tracker) Read(b []byte) (int, error) {
+	n, err := t.body.Read(b)
+	switch err {
+	case nil:
+		t.respSize += int64(n)
+		return n, nil
+	case io.EOF:
+		t.end()
+	}
+	return n, err
+}
+
+func (t *tracker) Close() error {
+	// Invoking endSpan on Close will help catch the cases
+	// in which a read returned a non-nil error, we set the
+	// span status but didn't end the span.
+	t.end()
+	return t.body.Close()
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/doc.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/doc.go
@@ -1,0 +1,19 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ochttp provides OpenCensus instrumentation for net/http package.
+//
+// For server instrumentation, see Handler. For client-side instrumentation,
+// see Transport.
+package ochttp // import "go.opencensus.io/plugin/ochttp"

--- a/vendor/go.opencensus.io/plugin/ochttp/propagation/b3/b3.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/propagation/b3/b3.go
@@ -1,0 +1,123 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package b3 contains a propagation.HTTPFormat implementation
+// for B3 propagation. See https://github.com/openzipkin/b3-propagation
+// for more details.
+package b3 // import "go.opencensus.io/plugin/ochttp/propagation/b3"
+
+import (
+	"encoding/hex"
+	"net/http"
+
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// B3 headers that OpenCensus understands.
+const (
+	TraceIDHeader = "X-B3-TraceId"
+	SpanIDHeader  = "X-B3-SpanId"
+	SampledHeader = "X-B3-Sampled"
+)
+
+// HTTPFormat implements propagation.HTTPFormat to propagate
+// traces in HTTP headers in B3 propagation format.
+// HTTPFormat skips the X-B3-ParentId and X-B3-Flags headers
+// because there are additional fields not represented in the
+// OpenCensus span context. Spans created from the incoming
+// header will be the direct children of the client-side span.
+// Similarly, reciever of the outgoing spans should use client-side
+// span created by OpenCensus as the parent.
+type HTTPFormat struct{}
+
+var _ propagation.HTTPFormat = (*HTTPFormat)(nil)
+
+// SpanContextFromRequest extracts a B3 span context from incoming requests.
+func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanContext, ok bool) {
+	tid, ok := ParseTraceID(req.Header.Get(TraceIDHeader))
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sid, ok := ParseSpanID(req.Header.Get(SpanIDHeader))
+	if !ok {
+		return trace.SpanContext{}, false
+	}
+	sampled, _ := ParseSampled(req.Header.Get(SampledHeader))
+	return trace.SpanContext{
+		TraceID:      tid,
+		SpanID:       sid,
+		TraceOptions: sampled,
+	}, true
+}
+
+// ParseTraceID parses the value of the X-B3-TraceId header.
+func ParseTraceID(tid string) (trace.TraceID, bool) {
+	if tid == "" {
+		return trace.TraceID{}, false
+	}
+	b, err := hex.DecodeString(tid)
+	if err != nil {
+		return trace.TraceID{}, false
+	}
+	var traceID trace.TraceID
+	if len(b) <= 8 {
+		// The lower 64-bits.
+		start := 8 + (8 - len(b))
+		copy(traceID[start:], b)
+	} else {
+		start := 16 - len(b)
+		copy(traceID[start:], b)
+	}
+
+	return traceID, true
+}
+
+// ParseSpanID parses the value of the X-B3-SpanId or X-B3-ParentSpanId headers.
+func ParseSpanID(sid string) (spanID trace.SpanID, ok bool) {
+	if sid == "" {
+		return trace.SpanID{}, false
+	}
+	b, err := hex.DecodeString(sid)
+	if err != nil {
+		return trace.SpanID{}, false
+	}
+	start := 8 - len(b)
+	copy(spanID[start:], b)
+	return spanID, true
+}
+
+// ParseSampled parses the value of the X-B3-Sampled header.
+func ParseSampled(sampled string) (trace.TraceOptions, bool) {
+	switch sampled {
+	case "true", "1":
+		return trace.TraceOptions(1), true
+	default:
+		return trace.TraceOptions(0), false
+	}
+}
+
+// SpanContextToRequest modifies the given request to include B3 headers.
+func (f *HTTPFormat) SpanContextToRequest(sc trace.SpanContext, req *http.Request) {
+	req.Header.Set(TraceIDHeader, hex.EncodeToString(sc.TraceID[:]))
+	req.Header.Set(SpanIDHeader, hex.EncodeToString(sc.SpanID[:]))
+
+	var sampled string
+	if sc.IsSampled() {
+		sampled = "1"
+	} else {
+		sampled = "0"
+	}
+	req.Header.Set(SampledHeader, sampled)
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/server.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/server.go
@@ -1,0 +1,217 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// Handler is a http.Handler that is aware of the incoming request's span.
+//
+// The extracted span can be accessed from the incoming request's
+// context.
+//
+//    span := trace.FromContext(r.Context())
+//
+// The server span will be automatically ended at the end of ServeHTTP.
+//
+// Incoming propagation mechanism is determined by the given HTTP propagators.
+type Handler struct {
+	// Propagation defines how traces are propagated. If unspecified,
+	// B3 propagation will be used.
+	Propagation propagation.HTTPFormat
+
+	// Handler is the handler used to handle the incoming request.
+	Handler http.Handler
+
+	// StartOptions are applied to the span started by this Handler around each
+	// request.
+	//
+	// StartOptions.SpanKind will always be set to trace.SpanKindServer
+	// for spans started by this transport.
+	StartOptions trace.StartOptions
+
+	// IsPublicEndpoint should be set to true for publicly accessible HTTP(S)
+	// servers. If true, any trace metadata set on the incoming request will
+	// be added as a linked trace instead of being added as a parent of the
+	// current trace.
+	IsPublicEndpoint bool
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var traceEnd, statsEnd func()
+	r, traceEnd = h.startTrace(w, r)
+	defer traceEnd()
+	w, statsEnd = h.startStats(w, r)
+	defer statsEnd()
+	handler := h.Handler
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+	handler.ServeHTTP(w, r)
+}
+
+func (h *Handler) startTrace(w http.ResponseWriter, r *http.Request) (*http.Request, func()) {
+	name := spanNameFromURL(r.URL)
+	ctx := r.Context()
+	var span *trace.Span
+	sc, ok := h.extractSpanContext(r)
+	if ok && !h.IsPublicEndpoint {
+		ctx, span = trace.StartSpanWithRemoteParent(ctx, name, sc,
+			trace.WithSampler(h.StartOptions.Sampler),
+			trace.WithSpanKind(trace.SpanKindServer))
+	} else {
+		ctx, span = trace.StartSpan(ctx, name,
+			trace.WithSampler(h.StartOptions.Sampler),
+			trace.WithSpanKind(trace.SpanKindServer),
+		)
+		if ok {
+			span.AddLink(trace.Link{
+				TraceID:    sc.TraceID,
+				SpanID:     sc.SpanID,
+				Type:       trace.LinkTypeChild,
+				Attributes: nil,
+			})
+		}
+	}
+	span.AddAttributes(requestAttrs(r)...)
+	return r.WithContext(ctx), span.End
+}
+
+func (h *Handler) extractSpanContext(r *http.Request) (trace.SpanContext, bool) {
+	if h.Propagation == nil {
+		return defaultFormat.SpanContextFromRequest(r)
+	}
+	return h.Propagation.SpanContextFromRequest(r)
+}
+
+func (h *Handler) startStats(w http.ResponseWriter, r *http.Request) (http.ResponseWriter, func()) {
+	ctx, _ := tag.New(r.Context(),
+		tag.Upsert(Host, r.URL.Host),
+		tag.Upsert(Path, r.URL.Path),
+		tag.Upsert(Method, r.Method))
+	track := &trackingResponseWriter{
+		start:  time.Now(),
+		ctx:    ctx,
+		writer: w,
+	}
+	if r.Body == nil {
+		// TODO: Handle cases where ContentLength is not set.
+		track.reqSize = -1
+	} else if r.ContentLength > 0 {
+		track.reqSize = r.ContentLength
+	}
+	stats.Record(ctx, ServerRequestCount.M(1))
+	return track, track.end
+}
+
+type trackingResponseWriter struct {
+	ctx        context.Context
+	reqSize    int64
+	respSize   int64
+	start      time.Time
+	statusCode int
+	statusLine string
+	endOnce    sync.Once
+	writer     http.ResponseWriter
+}
+
+// Compile time assertions for widely used net/http interfaces
+var _ http.CloseNotifier = (*trackingResponseWriter)(nil)
+var _ http.Flusher = (*trackingResponseWriter)(nil)
+var _ http.Hijacker = (*trackingResponseWriter)(nil)
+var _ http.Pusher = (*trackingResponseWriter)(nil)
+var _ http.ResponseWriter = (*trackingResponseWriter)(nil)
+
+var errHijackerUnimplemented = errors.New("ResponseWriter does not implement http.Hijacker")
+
+func (t *trackingResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hj, ok := t.writer.(http.Hijacker)
+	if !ok {
+		return nil, nil, errHijackerUnimplemented
+	}
+	return hj.Hijack()
+}
+
+func (t *trackingResponseWriter) CloseNotify() <-chan bool {
+	cn, ok := t.writer.(http.CloseNotifier)
+	if !ok {
+		return nil
+	}
+	return cn.CloseNotify()
+}
+
+func (t *trackingResponseWriter) Push(target string, opts *http.PushOptions) error {
+	pusher, ok := t.writer.(http.Pusher)
+	if !ok {
+		return http.ErrNotSupported
+	}
+	return pusher.Push(target, opts)
+}
+
+func (t *trackingResponseWriter) end() {
+	t.endOnce.Do(func() {
+		if t.statusCode == 0 {
+			t.statusCode = 200
+		}
+
+		span := trace.FromContext(t.ctx)
+		span.SetStatus(TraceStatus(t.statusCode, t.statusLine))
+
+		m := []stats.Measurement{
+			ServerLatency.M(float64(time.Since(t.start)) / float64(time.Millisecond)),
+			ServerResponseBytes.M(t.respSize),
+		}
+		if t.reqSize >= 0 {
+			m = append(m, ServerRequestBytes.M(t.reqSize))
+		}
+		ctx, _ := tag.New(t.ctx, tag.Upsert(StatusCode, strconv.Itoa(t.statusCode)))
+		stats.Record(ctx, m...)
+	})
+}
+
+func (t *trackingResponseWriter) Header() http.Header {
+	return t.writer.Header()
+}
+
+func (t *trackingResponseWriter) Write(data []byte) (int, error) {
+	n, err := t.writer.Write(data)
+	t.respSize += int64(n)
+	return n, err
+}
+
+func (t *trackingResponseWriter) WriteHeader(statusCode int) {
+	t.writer.WriteHeader(statusCode)
+	t.statusCode = statusCode
+	t.statusLine = http.StatusText(t.statusCode)
+}
+
+func (t *trackingResponseWriter) Flush() {
+	if flusher, ok := t.writer.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/stats.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/stats.go
@@ -1,0 +1,173 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+// The following client HTTP measures are supported for use in custom views.
+var (
+	ClientRequestCount  = stats.Int64("opencensus.io/http/client/request_count", "Number of HTTP requests started", stats.UnitDimensionless)
+	ClientRequestBytes  = stats.Int64("opencensus.io/http/client/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	ClientResponseBytes = stats.Int64("opencensus.io/http/client/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
+	ClientLatency       = stats.Float64("opencensus.io/http/client/latency", "End-to-end latency", stats.UnitMilliseconds)
+)
+
+// The following server HTTP measures are supported for use in custom views:
+var (
+	ServerRequestCount  = stats.Int64("opencensus.io/http/server/request_count", "Number of HTTP requests started", stats.UnitDimensionless)
+	ServerRequestBytes  = stats.Int64("opencensus.io/http/server/request_bytes", "HTTP request body size if set as ContentLength (uncompressed)", stats.UnitBytes)
+	ServerResponseBytes = stats.Int64("opencensus.io/http/server/response_bytes", "HTTP response body size (uncompressed)", stats.UnitBytes)
+	ServerLatency       = stats.Float64("opencensus.io/http/server/latency", "End-to-end latency", stats.UnitMilliseconds)
+)
+
+// The following tags are applied to stats recorded by this package. Host, Path
+// and Method are applied to all measures. StatusCode is not applied to
+// ClientRequestCount or ServerRequestCount, since it is recorded before the status is known.
+var (
+	// Host is the value of the HTTP Host header.
+	Host, _ = tag.NewKey("http.host")
+
+	// StatusCode is the numeric HTTP response status code,
+	// or "error" if a transport error occurred and no status code was read.
+	StatusCode, _ = tag.NewKey("http.status")
+
+	// Path is the URL path (not including query string) in the request.
+	Path, _ = tag.NewKey("http.path")
+
+	// Method is the HTTP method of the request, capitalized (GET, POST, etc.).
+	Method, _ = tag.NewKey("http.method")
+)
+
+// Default distributions used by views in this package.
+var (
+	DefaultSizeDistribution    = view.Distribution(0, 1024, 2048, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864, 268435456, 1073741824, 4294967296)
+	DefaultLatencyDistribution = view.Distribution(0, 1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1000, 2000, 5000, 10000, 20000, 50000, 100000)
+)
+
+// Package ochttp provides some convenience views.
+// You need to subscribe to the views for data to actually be collected.
+var (
+	ClientRequestCountView = &view.View{
+		Name:        "opencensus.io/http/client/request_count",
+		Description: "Count of HTTP requests started",
+		Measure:     ClientRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ClientRequestBytesView = &view.View{
+		Name:        "opencensus.io/http/client/request_bytes",
+		Description: "Size distribution of HTTP request body",
+		Measure:     ClientRequestBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ClientResponseBytesView = &view.View{
+		Name:        "opencensus.io/http/client/response_bytes",
+		Description: "Size distribution of HTTP response body",
+		Measure:     ClientResponseBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ClientLatencyView = &view.View{
+		Name:        "opencensus.io/http/client/latency",
+		Description: "Latency distribution of HTTP requests",
+		Measure:     ClientLatency,
+		Aggregation: DefaultLatencyDistribution,
+	}
+
+	ClientRequestCountByMethod = &view.View{
+		Name:        "opencensus.io/http/client/request_count_by_method",
+		Description: "Client request count by HTTP method",
+		TagKeys:     []tag.Key{Method},
+		Measure:     ClientRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ClientResponseCountByStatusCode = &view.View{
+		Name:        "opencensus.io/http/client/response_count_by_status_code",
+		Description: "Client response count by status code",
+		TagKeys:     []tag.Key{StatusCode},
+		Measure:     ClientLatency,
+		Aggregation: view.Count(),
+	}
+
+	ServerRequestCountView = &view.View{
+		Name:        "opencensus.io/http/server/request_count",
+		Description: "Count of HTTP requests started",
+		Measure:     ServerRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ServerRequestBytesView = &view.View{
+		Name:        "opencensus.io/http/server/request_bytes",
+		Description: "Size distribution of HTTP request body",
+		Measure:     ServerRequestBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ServerResponseBytesView = &view.View{
+		Name:        "opencensus.io/http/server/response_bytes",
+		Description: "Size distribution of HTTP response body",
+		Measure:     ServerResponseBytes,
+		Aggregation: DefaultSizeDistribution,
+	}
+
+	ServerLatencyView = &view.View{
+		Name:        "opencensus.io/http/server/latency",
+		Description: "Latency distribution of HTTP requests",
+		Measure:     ServerLatency,
+		Aggregation: DefaultLatencyDistribution,
+	}
+
+	ServerRequestCountByMethod = &view.View{
+		Name:        "opencensus.io/http/server/request_count_by_method",
+		Description: "Server request count by HTTP method",
+		TagKeys:     []tag.Key{Method},
+		Measure:     ServerRequestCount,
+		Aggregation: view.Count(),
+	}
+
+	ServerResponseCountByStatusCode = &view.View{
+		Name:        "opencensus.io/http/server/response_count_by_status_code",
+		Description: "Server response count by status code",
+		TagKeys:     []tag.Key{StatusCode},
+		Measure:     ServerLatency,
+		Aggregation: view.Count(),
+	}
+)
+
+// DefaultClientViews are the default client views provided by this package.
+var DefaultClientViews = []*view.View{
+	ClientRequestCountView,
+	ClientRequestBytesView,
+	ClientResponseBytesView,
+	ClientLatencyView,
+	ClientRequestCountByMethod,
+	ClientResponseCountByStatusCode,
+}
+
+// DefaultServerViews are the default server views provided by this package.
+var DefaultServerViews = []*view.View{
+	ServerRequestCountView,
+	ServerRequestBytesView,
+	ServerResponseBytesView,
+	ServerLatencyView,
+	ServerRequestCountByMethod,
+	ServerResponseCountByStatusCode,
+}

--- a/vendor/go.opencensus.io/plugin/ochttp/trace.go
+++ b/vendor/go.opencensus.io/plugin/ochttp/trace.go
@@ -1,0 +1,199 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ochttp
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/trace"
+	"go.opencensus.io/trace/propagation"
+)
+
+// TODO(jbd): Add godoc examples.
+
+var defaultFormat propagation.HTTPFormat = &b3.HTTPFormat{}
+
+// Attributes recorded on the span for the requests.
+// Only trace exporters will need them.
+const (
+	HostAttribute       = "http.host"
+	MethodAttribute     = "http.method"
+	PathAttribute       = "http.path"
+	UserAgentAttribute  = "http.user_agent"
+	StatusCodeAttribute = "http.status_code"
+)
+
+type traceTransport struct {
+	base         http.RoundTripper
+	startOptions trace.StartOptions
+	format       propagation.HTTPFormat
+}
+
+// TODO(jbd): Add message events for request and response size.
+
+// RoundTrip creates a trace.Span and inserts it into the outgoing request's headers.
+// The created span can follow a parent span, if a parent is presented in
+// the request's context.
+func (t *traceTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	name := spanNameFromURL(req.URL)
+	// TODO(jbd): Discuss whether we want to prefix
+	// outgoing requests with Sent.
+	_, span := trace.StartSpan(req.Context(), name,
+		trace.WithSampler(t.startOptions.Sampler),
+		trace.WithSpanKind(trace.SpanKindClient))
+
+	req = req.WithContext(trace.WithSpan(req.Context(), span))
+	if t.format != nil {
+		t.format.SpanContextToRequest(span.SpanContext(), req)
+	}
+
+	span.AddAttributes(requestAttrs(req)...)
+	resp, err := t.base.RoundTrip(req)
+	if err != nil {
+		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
+		span.End()
+		return resp, err
+	}
+
+	span.AddAttributes(responseAttrs(resp)...)
+	span.SetStatus(TraceStatus(resp.StatusCode, resp.Status))
+
+	// span.End() will be invoked after
+	// a read from resp.Body returns io.EOF or when
+	// resp.Body.Close() is invoked.
+	resp.Body = &bodyTracker{rc: resp.Body, span: span}
+	return resp, err
+}
+
+// bodyTracker wraps a response.Body and invokes
+// trace.EndSpan on encountering io.EOF on reading
+// the body of the original response.
+type bodyTracker struct {
+	rc   io.ReadCloser
+	span *trace.Span
+}
+
+var _ io.ReadCloser = (*bodyTracker)(nil)
+
+func (bt *bodyTracker) Read(b []byte) (int, error) {
+	n, err := bt.rc.Read(b)
+
+	switch err {
+	case nil:
+		return n, nil
+	case io.EOF:
+		bt.span.End()
+	default:
+		// For all other errors, set the span status
+		bt.span.SetStatus(trace.Status{
+			// Code 2 is the error code for Internal server error.
+			Code:    2,
+			Message: err.Error(),
+		})
+	}
+	return n, err
+}
+
+func (bt *bodyTracker) Close() error {
+	// Invoking endSpan on Close will help catch the cases
+	// in which a read returned a non-nil error, we set the
+	// span status but didn't end the span.
+	bt.span.End()
+	return bt.rc.Close()
+}
+
+// CancelRequest cancels an in-flight request by closing its connection.
+func (t *traceTransport) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+	if cr, ok := t.base.(canceler); ok {
+		cr.CancelRequest(req)
+	}
+}
+
+func spanNameFromURL(u *url.URL) string {
+	return u.Path
+}
+
+func requestAttrs(r *http.Request) []trace.Attribute {
+	return []trace.Attribute{
+		trace.StringAttribute(PathAttribute, r.URL.Path),
+		trace.StringAttribute(HostAttribute, r.URL.Host),
+		trace.StringAttribute(MethodAttribute, r.Method),
+		trace.StringAttribute(UserAgentAttribute, r.UserAgent()),
+	}
+}
+
+func responseAttrs(resp *http.Response) []trace.Attribute {
+	return []trace.Attribute{
+		trace.Int64Attribute(StatusCodeAttribute, int64(resp.StatusCode)),
+	}
+}
+
+// HTTPStatusToTraceStatus converts the HTTP status code to a trace.Status that
+// represents the outcome as closely as possible.
+func TraceStatus(httpStatusCode int, statusLine string) trace.Status {
+	var code int32
+	if httpStatusCode < 200 || httpStatusCode >= 400 {
+		code = trace.StatusCodeUnknown
+	}
+	switch httpStatusCode {
+	case 499:
+		code = trace.StatusCodeCancelled
+	case http.StatusBadRequest:
+		code = trace.StatusCodeInvalidArgument
+	case http.StatusGatewayTimeout:
+		code = trace.StatusCodeDeadlineExceeded
+	case http.StatusNotFound:
+		code = trace.StatusCodeNotFound
+	case http.StatusForbidden:
+		code = trace.StatusCodePermissionDenied
+	case http.StatusUnauthorized: // 401 is actually unauthenticated.
+		code = trace.StatusCodeUnauthenticated
+	case http.StatusTooManyRequests:
+		code = trace.StatusCodeResourceExhausted
+	case http.StatusNotImplemented:
+		code = trace.StatusCodeUnimplemented
+	case http.StatusServiceUnavailable:
+		code = trace.StatusCodeUnavailable
+	case http.StatusOK:
+		code = trace.StatusCodeOK
+	}
+	return trace.Status{Code: code, Message: codeToStr[code]}
+}
+
+var codeToStr = map[int32]string{
+	trace.StatusCodeOK:                 `"OK"`,
+	trace.StatusCodeCancelled:          `"CANCELLED"`,
+	trace.StatusCodeUnknown:            `"UNKNOWN"`,
+	trace.StatusCodeInvalidArgument:    `"INVALID_ARGUMENT"`,
+	trace.StatusCodeDeadlineExceeded:   `"DEADLINE_EXCEEDED"`,
+	trace.StatusCodeNotFound:           `"NOT_FOUND"`,
+	trace.StatusCodeAlreadyExists:      `"ALREADY_EXISTS"`,
+	trace.StatusCodePermissionDenied:   `"PERMISSION_DENIED"`,
+	trace.StatusCodeResourceExhausted:  `"RESOURCE_EXHAUSTED"`,
+	trace.StatusCodeFailedPrecondition: `"FAILED_PRECONDITION"`,
+	trace.StatusCodeAborted:            `"ABORTED"`,
+	trace.StatusCodeOutOfRange:         `"OUT_OF_RANGE"`,
+	trace.StatusCodeUnimplemented:      `"UNIMPLEMENTED"`,
+	trace.StatusCodeInternal:           `"INTERNAL"`,
+	trace.StatusCodeUnavailable:        `"UNAVAILABLE"`,
+	trace.StatusCodeDataLoss:           `"DATA_LOSS"`,
+	trace.StatusCodeUnauthenticated:    `"UNAUTHENTICATED"`,
+}

--- a/vendor/go.opencensus.io/stats/doc.go
+++ b/vendor/go.opencensus.io/stats/doc.go
@@ -1,0 +1,55 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+Package stats contains support for OpenCensus stats recording.
+
+OpenCensus allows users to create typed measures, record measurements,
+aggregate the collected data, and export the aggregated data.
+
+Measures
+
+A measure represents a type of metric to be tracked and recorded.
+For example, latency, request Mb/s, and response Mb/s are measures
+to collect from a server.
+
+Each measure needs to be registered before being used. Measure
+constructors such as Int64 and Float64 automatically
+register the measure by the given name. Each registered measure needs
+to be unique by name. Measures also have a description and a unit.
+
+Libraries can define and export measures for their end users to
+create views and collect instrumentation data.
+
+Recording measurements
+
+Measurement is a data point to be collected for a measure. For example,
+for a latency (ms) measure, 100 is a measurement that represents a 100ms
+latency event. Users collect data points on the existing measures with
+the current context. Tags from the current context are recorded with the
+measurements if they are any.
+
+Recorded measurements are dropped immediately if user is not aggregating
+them via views. Users don't necessarily need to conditionally enable/disable
+recording to reduce cost. Recording of measurements is cheap.
+
+Libraries can always record measurements, and end-users can later decide
+on which measurements they want to collect by registering views. This allows
+libraries to turn on the instrumentation by default.
+*/
+package stats // import "go.opencensus.io/stats"
+
+// TODO(acetechnologist): Add a link to the language independent OpenCensus
+// spec when it is available.

--- a/vendor/go.opencensus.io/stats/internal/record.go
+++ b/vendor/go.opencensus.io/stats/internal/record.go
@@ -1,0 +1,25 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"go.opencensus.io/tag"
+)
+
+// DefaultRecorder will be called for each Record call.
+var DefaultRecorder func(*tag.Map, interface{})
+
+// SubscriptionReporter reports when a view subscribed with a measure.
+var SubscriptionReporter func(measure string)

--- a/vendor/go.opencensus.io/stats/internal/validation.go
+++ b/vendor/go.opencensus.io/stats/internal/validation.go
@@ -1,0 +1,28 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal // import "go.opencensus.io/stats/internal"
+
+const (
+	MaxNameLength = 255
+)
+
+func IsPrintable(str string) bool {
+	for _, r := range str {
+		if !(r >= ' ' && r <= '~') {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/go.opencensus.io/stats/measure.go
+++ b/vendor/go.opencensus.io/stats/measure.go
@@ -1,0 +1,96 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// Measure represents a type of metric to be tracked and recorded.
+// For example, latency, request Mb/s, and response Mb/s are measures
+// to collect from a server.
+//
+// Each measure needs to be registered before being used.
+// Measure constructors such as Int64 and
+// Float64 automatically registers the measure
+// by the given name.
+// Each registered measure needs to be unique by name.
+// Measures also have a description and a unit.
+type Measure interface {
+	Name() string
+	Description() string
+	Unit() string
+}
+
+// measureDescriptor is the untyped descriptor associated with each measure.
+// Int64Measure and Float64Measure wrap measureDescriptor to provide typed
+// recording APIs.
+// Two Measures with the same name will have the same measureDescriptor.
+type measureDescriptor struct {
+	subs int32 // access atomically
+
+	name        string
+	description string
+	unit        string
+}
+
+func (m *measureDescriptor) subscribe() {
+	atomic.StoreInt32(&m.subs, 1)
+}
+
+func (m *measureDescriptor) subscribed() bool {
+	return atomic.LoadInt32(&m.subs) == 1
+}
+
+var (
+	mu       sync.RWMutex
+	measures = make(map[string]*measureDescriptor)
+)
+
+func registerMeasureHandle(name, desc, unit string) *measureDescriptor {
+	mu.Lock()
+	defer mu.Unlock()
+
+	if stored, ok := measures[name]; ok {
+		return stored
+	}
+	m := &measureDescriptor{
+		name:        name,
+		description: desc,
+		unit:        unit,
+	}
+	measures[name] = m
+	return m
+}
+
+// Measurement is the numeric value measured when recording stats. Each measure
+// provides methods to create measurements of their kind. For example, Int64Measure
+// provides M to convert an int64 into a measurement.
+type Measurement struct {
+	v float64
+	m Measure
+}
+
+// Value returns the value of the Measurement as a float64.
+func (m Measurement) Value() float64 {
+	return m.v
+}
+
+// Measure returns the Measure from which this Measurement was created.
+func (m Measurement) Measure() Measure {
+	return m.m
+}

--- a/vendor/go.opencensus.io/stats/measure_float64.go
+++ b/vendor/go.opencensus.io/stats/measure_float64.go
@@ -1,0 +1,52 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+// Float64Measure is a measure of type float64.
+type Float64Measure struct {
+	md *measureDescriptor
+}
+
+// Name returns the name of the measure.
+func (m *Float64Measure) Name() string {
+	return m.md.name
+}
+
+// Description returns the description of the measure.
+func (m *Float64Measure) Description() string {
+	return m.md.description
+}
+
+// Unit returns the unit of the measure.
+func (m *Float64Measure) Unit() string {
+	return m.md.unit
+}
+
+// M creates a new float64 measurement.
+// Use Record to record measurements.
+func (m *Float64Measure) M(v float64) Measurement {
+	if !m.md.subscribed() {
+		return Measurement{}
+	}
+	return Measurement{m: m, v: v}
+}
+
+// Float64 creates a new measure of type Float64Measure.
+// It never returns an error.
+func Float64(name, description, unit string) *Float64Measure {
+	mi := registerMeasureHandle(name, description, unit)
+	return &Float64Measure{mi}
+}

--- a/vendor/go.opencensus.io/stats/measure_int64.go
+++ b/vendor/go.opencensus.io/stats/measure_int64.go
@@ -1,0 +1,52 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+// Int64Measure is a measure of type int64.
+type Int64Measure struct {
+	md *measureDescriptor
+}
+
+// Name returns the name of the measure.
+func (m *Int64Measure) Name() string {
+	return m.md.name
+}
+
+// Description returns the description of the measure.
+func (m *Int64Measure) Description() string {
+	return m.md.description
+}
+
+// Unit returns the unit of the measure.
+func (m *Int64Measure) Unit() string {
+	return m.md.unit
+}
+
+// M creates a new int64 measurement.
+// Use Record to record measurements.
+func (m *Int64Measure) M(v int64) Measurement {
+	if !m.md.subscribed() {
+		return Measurement{}
+	}
+	return Measurement{m: m, v: float64(v)}
+}
+
+// Int64 creates a new measure of type Int64Measure.
+// It never returns an error.
+func Int64(name, description, unit string) *Int64Measure {
+	mi := registerMeasureHandle(name, description, unit)
+	return &Int64Measure{mi}
+}

--- a/vendor/go.opencensus.io/stats/record.go
+++ b/vendor/go.opencensus.io/stats/record.go
@@ -1,0 +1,52 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+import (
+	"context"
+
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+func init() {
+	internal.SubscriptionReporter = func(measure string) {
+		mu.Lock()
+		measures[measure].subscribe()
+		mu.Unlock()
+	}
+}
+
+// Record records one or multiple measurements with the same tags at once.
+// If there are any tags in the context, measurements will be tagged with them.
+func Record(ctx context.Context, ms ...Measurement) {
+	if len(ms) == 0 {
+		return
+	}
+	var record bool
+	for _, m := range ms {
+		if (m != Measurement{}) {
+			record = true
+			break
+		}
+	}
+	if !record {
+		return
+	}
+	if internal.DefaultRecorder != nil {
+		internal.DefaultRecorder(tag.FromContext(ctx), ms)
+	}
+}

--- a/vendor/go.opencensus.io/stats/units.go
+++ b/vendor/go.opencensus.io/stats/units.go
@@ -1,0 +1,25 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package stats
+
+// Units are encoded according to the case-sensitive abbreviations from the
+// Unified Code for Units of Measure: http://unitsofmeasure.org/ucum.html
+const (
+	UnitNone          = "1" // Deprecated: Use UnitDimensionless.
+	UnitDimensionless = "1"
+	UnitBytes         = "By"
+	UnitMilliseconds  = "ms"
+)

--- a/vendor/go.opencensus.io/stats/view/aggregation.go
+++ b/vendor/go.opencensus.io/stats/view/aggregation.go
@@ -1,0 +1,120 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+// AggType represents the type of aggregation function used on a View.
+type AggType int
+
+// All available aggregation types.
+const (
+	AggTypeNone         AggType = iota // no aggregation; reserved for future use.
+	AggTypeCount                       // the count aggregation, see Count.
+	AggTypeSum                         // the sum aggregation, see Sum.
+	AggTypeDistribution                // the distribution aggregation, see Distribution.
+	AggTypeLastValue                   // the last value aggregation, see LastValue.
+)
+
+func (t AggType) String() string {
+	return aggTypeName[t]
+}
+
+var aggTypeName = map[AggType]string{
+	AggTypeNone:         "None",
+	AggTypeCount:        "Count",
+	AggTypeSum:          "Sum",
+	AggTypeDistribution: "Distribution",
+	AggTypeLastValue:    "LastValue",
+}
+
+// Aggregation represents a data aggregation method. Use one of the functions:
+// Count, Sum, or Distribution to construct an Aggregation.
+type Aggregation struct {
+	Type    AggType   // Type is the AggType of this Aggregation.
+	Buckets []float64 // Buckets are the bucket endpoints if this Aggregation represents a distribution, see Distribution.
+
+	newData func() AggregationData
+}
+
+var (
+	aggCount = &Aggregation{
+		Type: AggTypeCount,
+		newData: func() AggregationData {
+			return &CountData{}
+		},
+	}
+	aggSum = &Aggregation{
+		Type: AggTypeSum,
+		newData: func() AggregationData {
+			return &SumData{}
+		},
+	}
+)
+
+// Count indicates that data collected and aggregated
+// with this method will be turned into a count value.
+// For example, total number of accepted requests can be
+// aggregated by using Count.
+func Count() *Aggregation {
+	return aggCount
+}
+
+// Sum indicates that data collected and aggregated
+// with this method will be summed up.
+// For example, accumulated request bytes can be aggregated by using
+// Sum.
+func Sum() *Aggregation {
+	return aggSum
+}
+
+// Distribution indicates that the desired aggregation is
+// a histogram distribution.
+//
+// An distribution aggregation may contain a histogram of the values in the
+// population. The bucket boundaries for that histogram are described
+// by the bounds. This defines len(bounds)+1 buckets.
+//
+// If len(bounds) >= 2 then the boundaries for bucket index i are:
+//
+//     [-infinity, bounds[i]) for i = 0
+//     [bounds[i-1], bounds[i]) for 0 < i < length
+//     [bounds[i-1], +infinity) for i = length
+//
+// If len(bounds) is 0 then there is no histogram associated with the
+// distribution. There will be a single bucket with boundaries
+// (-infinity, +infinity).
+//
+// If len(bounds) is 1 then there is no finite buckets, and that single
+// element is the common boundary of the overflow and underflow buckets.
+func Distribution(bounds ...float64) *Aggregation {
+	return &Aggregation{
+		Type:    AggTypeDistribution,
+		Buckets: bounds,
+		newData: func() AggregationData {
+			return newDistributionData(bounds)
+		},
+	}
+}
+
+// LastValue only reports the last value recorded using this
+// aggregation. All other measurements will be dropped.
+func LastValue() *Aggregation {
+	return &Aggregation{
+		Type: AggTypeLastValue,
+		newData: func() AggregationData {
+			return &LastValueData{}
+		},
+	}
+}

--- a/vendor/go.opencensus.io/stats/view/aggregation_data.go
+++ b/vendor/go.opencensus.io/stats/view/aggregation_data.go
@@ -1,0 +1,207 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"math"
+)
+
+// AggregationData represents an aggregated value from a collection.
+// They are reported on the view data during exporting.
+// Mosts users won't directly access aggregration data.
+type AggregationData interface {
+	isAggregationData() bool
+	addSample(v float64)
+	clone() AggregationData
+	equal(other AggregationData) bool
+}
+
+const epsilon = 1e-9
+
+// CountData is the aggregated data for the Count aggregation.
+// A count aggregation processes data and counts the recordings.
+//
+// Most users won't directly access count data.
+type CountData struct {
+	Value int64
+}
+
+func (a *CountData) isAggregationData() bool { return true }
+
+func (a *CountData) addSample(v float64) {
+	a.Value = a.Value + 1
+}
+
+func (a *CountData) clone() AggregationData {
+	return &CountData{Value: a.Value}
+}
+
+func (a *CountData) equal(other AggregationData) bool {
+	a2, ok := other.(*CountData)
+	if !ok {
+		return false
+	}
+
+	return a.Value == a2.Value
+}
+
+// SumData is the aggregated data for the Sum aggregation.
+// A sum aggregation processes data and sums up the recordings.
+//
+// Most users won't directly access sum data.
+type SumData struct {
+	Value float64
+}
+
+func (a *SumData) isAggregationData() bool { return true }
+
+func (a *SumData) addSample(f float64) {
+	a.Value += f
+}
+
+func (a *SumData) clone() AggregationData {
+	return &SumData{Value: a.Value}
+}
+
+func (a *SumData) equal(other AggregationData) bool {
+	a2, ok := other.(*SumData)
+	if !ok {
+		return false
+	}
+	return math.Pow(a.Value-a2.Value, 2) < epsilon
+}
+
+// DistributionData is the aggregated data for the
+// Distribution aggregation.
+//
+// Most users won't directly access distribution data.
+type DistributionData struct {
+	Count           int64     // number of data points aggregated
+	Min             float64   // minimum value in the distribution
+	Max             float64   // max value in the distribution
+	Mean            float64   // mean of the distribution
+	SumOfSquaredDev float64   // sum of the squared deviation from the mean
+	CountPerBucket  []int64   // number of occurrences per bucket
+	bounds          []float64 // histogram distribution of the values
+}
+
+func newDistributionData(bounds []float64) *DistributionData {
+	return &DistributionData{
+		CountPerBucket: make([]int64, len(bounds)+1),
+		bounds:         bounds,
+		Min:            math.MaxFloat64,
+		Max:            math.SmallestNonzeroFloat64,
+	}
+}
+
+// Sum returns the sum of all samples collected.
+func (a *DistributionData) Sum() float64 { return a.Mean * float64(a.Count) }
+
+func (a *DistributionData) variance() float64 {
+	if a.Count <= 1 {
+		return 0
+	}
+	return a.SumOfSquaredDev / float64(a.Count-1)
+}
+
+func (a *DistributionData) isAggregationData() bool { return true }
+
+func (a *DistributionData) addSample(f float64) {
+	if f < a.Min {
+		a.Min = f
+	}
+	if f > a.Max {
+		a.Max = f
+	}
+	a.Count++
+	a.incrementBucketCount(f)
+
+	if a.Count == 1 {
+		a.Mean = f
+		return
+	}
+
+	oldMean := a.Mean
+	a.Mean = a.Mean + (f-a.Mean)/float64(a.Count)
+	a.SumOfSquaredDev = a.SumOfSquaredDev + (f-oldMean)*(f-a.Mean)
+}
+
+func (a *DistributionData) incrementBucketCount(f float64) {
+	if len(a.bounds) == 0 {
+		a.CountPerBucket[0]++
+		return
+	}
+
+	for i, b := range a.bounds {
+		if f < b {
+			a.CountPerBucket[i]++
+			return
+		}
+	}
+	a.CountPerBucket[len(a.bounds)]++
+}
+
+func (a *DistributionData) clone() AggregationData {
+	counts := make([]int64, len(a.CountPerBucket))
+	copy(counts, a.CountPerBucket)
+	c := *a
+	c.CountPerBucket = counts
+	return &c
+}
+
+func (a *DistributionData) equal(other AggregationData) bool {
+	a2, ok := other.(*DistributionData)
+	if !ok {
+		return false
+	}
+	if a2 == nil {
+		return false
+	}
+	if len(a.CountPerBucket) != len(a2.CountPerBucket) {
+		return false
+	}
+	for i := range a.CountPerBucket {
+		if a.CountPerBucket[i] != a2.CountPerBucket[i] {
+			return false
+		}
+	}
+	return a.Count == a2.Count && a.Min == a2.Min && a.Max == a2.Max && math.Pow(a.Mean-a2.Mean, 2) < epsilon && math.Pow(a.variance()-a2.variance(), 2) < epsilon
+}
+
+// LastValueData returns the last value recorded for LastValue aggregation.
+type LastValueData struct {
+	Value float64
+}
+
+func (l *LastValueData) isAggregationData() bool {
+	return true
+}
+
+func (l *LastValueData) addSample(v float64) {
+	l.Value = v
+}
+
+func (l *LastValueData) clone() AggregationData {
+	return &LastValueData{l.Value}
+}
+
+func (l *LastValueData) equal(other AggregationData) bool {
+	a2, ok := other.(*LastValueData)
+	if !ok {
+		return false
+	}
+	return l.Value == a2.Value
+}

--- a/vendor/go.opencensus.io/stats/view/collector.go
+++ b/vendor/go.opencensus.io/stats/view/collector.go
@@ -1,0 +1,84 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"sort"
+
+	"go.opencensus.io/internal/tagencoding"
+	"go.opencensus.io/tag"
+)
+
+type collector struct {
+	// signatures holds the aggregations values for each unique tag signature
+	// (values for all keys) to its aggregator.
+	signatures map[string]AggregationData
+	// Aggregation is the description of the aggregation to perform for this
+	// view.
+	a *Aggregation
+}
+
+func (c *collector) addSample(s string, v float64) {
+	aggregator, ok := c.signatures[s]
+	if !ok {
+		aggregator = c.a.newData()
+		c.signatures[s] = aggregator
+	}
+	aggregator.addSample(v)
+}
+
+func (c *collector) collectedRows(keys []tag.Key) []*Row {
+	var rows []*Row
+	for sig, aggregator := range c.signatures {
+		tags := decodeTags([]byte(sig), keys)
+		row := &Row{tags, aggregator}
+		rows = append(rows, row)
+	}
+	return rows
+}
+
+func (c *collector) clearRows() {
+	c.signatures = make(map[string]AggregationData)
+}
+
+// encodeWithKeys encodes the map by using values
+// only associated with the keys provided.
+func encodeWithKeys(m *tag.Map, keys []tag.Key) []byte {
+	vb := &tagencoding.Values{
+		Buffer: make([]byte, len(keys)),
+	}
+	for _, k := range keys {
+		v, _ := m.Value(k)
+		vb.WriteValue([]byte(v))
+	}
+	return vb.Bytes()
+}
+
+// decodeTags decodes tags from the buffer and
+// orders them by the keys.
+func decodeTags(buf []byte, keys []tag.Key) []tag.Tag {
+	vb := &tagencoding.Values{Buffer: buf}
+	var tags []tag.Tag
+	for _, k := range keys {
+		v := vb.ReadValue()
+		if v != nil {
+			tags = append(tags, tag.Tag{Key: k, Value: string(v)})
+		}
+	}
+	vb.ReadIndex = 0
+	sort.Slice(tags, func(i, j int) bool { return tags[i].Key.Name() < tags[j].Key.Name() })
+	return tags
+}

--- a/vendor/go.opencensus.io/stats/view/doc.go
+++ b/vendor/go.opencensus.io/stats/view/doc.go
@@ -1,0 +1,46 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+Package view contains support for collecting and exposing aggregates over stats.
+
+In order to collect measurements, views need to be defined and registered.
+A view allows recorded measurements to be filtered and aggregated over a time window.
+
+All recorded measurements can be filtered by a list of tags.
+
+OpenCensus provides several aggregation methods: count, distribution and sum.
+Count aggregation only counts the number of measurement points. Distribution
+aggregation provides statistical summary of the aggregated data. Sum distribution
+sums up the measurement points. Aggregations are cumulative.
+
+Users can dynamically create and delete views.
+
+Libraries can export their own views and claim the view names
+by registering them themselves.
+
+Exporting
+
+Collected and aggregated data can be exported to a metric collection
+backend by registering its exporter.
+
+Multiple exporters can be registered to upload the data to various
+different backends. Users need to unregister the exporters once they
+no longer are needed.
+*/
+package view // import "go.opencensus.io/stats/view"
+
+// TODO(acetechnologist): Add a link to the language independent OpenCensus
+// spec when it is available.

--- a/vendor/go.opencensus.io/stats/view/export.go
+++ b/vendor/go.opencensus.io/stats/view/export.go
@@ -1,0 +1,55 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package view
+
+import "sync"
+
+var (
+	exportersMu sync.RWMutex // guards exporters
+	exporters   = make(map[Exporter]struct{})
+)
+
+// Exporter exports the collected records as view data.
+//
+// The ExportView method should return quickly; if an
+// Exporter takes a significant amount of time to
+// process a Data, that work should be done on another goroutine.
+//
+// The Data should not be modified.
+type Exporter interface {
+	ExportView(viewData *Data)
+}
+
+// RegisterExporter registers an exporter.
+// Collected data will be reported via all the
+// registered exporters. Once you no longer
+// want data to be exported, invoke UnregisterExporter
+// with the previously registered exporter.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
+func RegisterExporter(e Exporter) {
+	exportersMu.Lock()
+	defer exportersMu.Unlock()
+
+	exporters[e] = struct{}{}
+}
+
+// UnregisterExporter unregisters an exporter.
+func UnregisterExporter(e Exporter) {
+	exportersMu.Lock()
+	defer exportersMu.Unlock()
+
+	delete(exporters, e)
+}

--- a/vendor/go.opencensus.io/stats/view/view.go
+++ b/vendor/go.opencensus.io/stats/view/view.go
@@ -1,0 +1,183 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+// View allows users to aggregate the recorded stats.Measurements.
+// Views need to be passed to the Subscribe function to be before data will be
+// collected and sent to Exporters.
+type View struct {
+	Name        string // Name of View. Must be unique. If unset, will default to the name of the Measure.
+	Description string // Description is a human-readable description for this view.
+
+	// TagKeys are the tag keys describing the grouping of this view.
+	// A single Row will be produced for each combination of associated tag values.
+	TagKeys []tag.Key
+
+	// Measure is a stats.Measure to aggregate in this view.
+	Measure stats.Measure
+
+	// Aggregation is the aggregation function tp apply to the set of Measurements.
+	Aggregation *Aggregation
+}
+
+// WithName returns a copy of the View with a new name. This is useful for
+// renaming views to cope with limitations placed on metric names by various
+// backends.
+func (v *View) WithName(name string) *View {
+	vNew := *v
+	vNew.Name = name
+	return &vNew
+}
+
+// same compares two views and returns true if they represent the same aggregation.
+func (v *View) same(other *View) bool {
+	if v == other {
+		return true
+	}
+	if v == nil {
+		return false
+	}
+	return reflect.DeepEqual(v.Aggregation, other.Aggregation) &&
+		v.Measure.Name() == other.Measure.Name()
+}
+
+// canonicalize canonicalizes v by setting explicit
+// defaults for Name and Description and sorting the TagKeys
+func (v *View) canonicalize() error {
+	if v.Measure == nil {
+		return fmt.Errorf("cannot subscribe view %q: measure not set", v.Name)
+	}
+	if v.Aggregation == nil {
+		return fmt.Errorf("cannot subscribe view %q: aggregation not set", v.Name)
+	}
+	if v.Name == "" {
+		v.Name = v.Measure.Name()
+	}
+	if v.Description == "" {
+		v.Description = v.Measure.Description()
+	}
+	if err := checkViewName(v.Name); err != nil {
+		return err
+	}
+	sort.Slice(v.TagKeys, func(i, j int) bool {
+		return v.TagKeys[i].Name() < v.TagKeys[j].Name()
+	})
+	return nil
+}
+
+// viewInternal is the internal representation of a View.
+type viewInternal struct {
+	view       *View  // view is the canonicalized View definition associated with this view.
+	subscribed uint32 // 1 if someone is subscribed and data need to be exported, use atomic to access
+	collector  *collector
+}
+
+func newViewInternal(v *View) (*viewInternal, error) {
+	return &viewInternal{
+		view:      v,
+		collector: &collector{make(map[string]AggregationData), v.Aggregation},
+	}, nil
+}
+
+func (v *viewInternal) subscribe() {
+	atomic.StoreUint32(&v.subscribed, 1)
+}
+
+func (v *viewInternal) unsubscribe() {
+	atomic.StoreUint32(&v.subscribed, 0)
+}
+
+// isSubscribed returns true if the view is exporting
+// data by subscription.
+func (v *viewInternal) isSubscribed() bool {
+	return atomic.LoadUint32(&v.subscribed) == 1
+}
+
+func (v *viewInternal) clearRows() {
+	v.collector.clearRows()
+}
+
+func (v *viewInternal) collectedRows() []*Row {
+	return v.collector.collectedRows(v.view.TagKeys)
+}
+
+func (v *viewInternal) addSample(m *tag.Map, val float64) {
+	if !v.isSubscribed() {
+		return
+	}
+	sig := string(encodeWithKeys(m, v.view.TagKeys))
+	v.collector.addSample(sig, val)
+}
+
+// A Data is a set of rows about usage of the single measure associated
+// with the given view. Each row is specific to a unique set of tags.
+type Data struct {
+	View       *View
+	Start, End time.Time
+	Rows       []*Row
+}
+
+// Row is the collected value for a specific set of key value pairs a.k.a tags.
+type Row struct {
+	Tags []tag.Tag
+	Data AggregationData
+}
+
+func (r *Row) String() string {
+	var buffer bytes.Buffer
+	buffer.WriteString("{ ")
+	buffer.WriteString("{ ")
+	for _, t := range r.Tags {
+		buffer.WriteString(fmt.Sprintf("{%v %v}", t.Key.Name(), t.Value))
+	}
+	buffer.WriteString(" }")
+	buffer.WriteString(fmt.Sprintf("%v", r.Data))
+	buffer.WriteString(" }")
+	return buffer.String()
+}
+
+// Equal returns true if both rows are equal. Tags are expected to be ordered
+// by the key name. Even both rows have the same tags but the tags appear in
+// different orders it will return false.
+func (r *Row) Equal(other *Row) bool {
+	if r == other {
+		return true
+	}
+	return reflect.DeepEqual(r.Tags, other.Tags) && r.Data.equal(other.Data)
+}
+
+func checkViewName(name string) error {
+	if len(name) > internal.MaxNameLength {
+		return fmt.Errorf("view name cannot be larger than %v", internal.MaxNameLength)
+	}
+	if !internal.IsPrintable(name) {
+		return fmt.Errorf("view name needs to be an ASCII string")
+	}
+	return nil
+}

--- a/vendor/go.opencensus.io/stats/view/worker.go
+++ b/vendor/go.opencensus.io/stats/view/worker.go
@@ -1,0 +1,231 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"fmt"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+func init() {
+	defaultWorker = newWorker()
+	go defaultWorker.start()
+	internal.DefaultRecorder = record
+}
+
+type measureRef struct {
+	measure string
+	views   map[*viewInternal]struct{}
+}
+
+type worker struct {
+	measures   map[string]*measureRef
+	views      map[string]*viewInternal
+	startTimes map[*viewInternal]time.Time
+
+	timer      *time.Ticker
+	c          chan command
+	quit, done chan bool
+}
+
+var defaultWorker *worker
+
+var defaultReportingDuration = 10 * time.Second
+
+// Find returns a subscribed view associated with this name.
+// If no subscribed view is found, nil is returned.
+func Find(name string) (v *View) {
+	req := &getViewByNameReq{
+		name: name,
+		c:    make(chan *getViewByNameResp),
+	}
+	defaultWorker.c <- req
+	resp := <-req.c
+	return resp.v
+}
+
+// Register begins collecting data for the given views.
+// Once a view is subscribed, it reports data to the registered exporters.
+func Register(views ...*View) error {
+	for _, v := range views {
+		if err := v.canonicalize(); err != nil {
+			return err
+		}
+	}
+	req := &registerViewReq{
+		views: views,
+		err:   make(chan error),
+	}
+	defaultWorker.c <- req
+	return <-req.err
+}
+
+// Unregister the given views. Data will not longer be exported for these views
+// after Unregister returns.
+// It is not necessary to unregister from views you expect to collect for the
+// duration of your program execution.
+func Unregister(views ...*View) {
+	names := make([]string, len(views))
+	for i := range views {
+		names[i] = views[i].Name
+	}
+	req := &unregisterFromViewReq{
+		views: names,
+		done:  make(chan struct{}),
+	}
+	defaultWorker.c <- req
+	<-req.done
+}
+
+func RetrieveData(viewName string) ([]*Row, error) {
+	req := &retrieveDataReq{
+		now: time.Now(),
+		v:   viewName,
+		c:   make(chan *retrieveDataResp),
+	}
+	defaultWorker.c <- req
+	resp := <-req.c
+	return resp.rows, resp.err
+}
+
+func record(tags *tag.Map, ms interface{}) {
+	req := &recordReq{
+		tm: tags,
+		ms: ms.([]stats.Measurement),
+	}
+	defaultWorker.c <- req
+}
+
+// SetReportingPeriod sets the interval between reporting aggregated views in
+// the program. If duration is less than or
+// equal to zero, it enables the default behavior.
+func SetReportingPeriod(d time.Duration) {
+	// TODO(acetechnologist): ensure that the duration d is more than a certain
+	// value. e.g. 1s
+	req := &setReportingPeriodReq{
+		d: d,
+		c: make(chan bool),
+	}
+	defaultWorker.c <- req
+	<-req.c // don't return until the timer is set to the new duration.
+}
+
+func newWorker() *worker {
+	return &worker{
+		measures:   make(map[string]*measureRef),
+		views:      make(map[string]*viewInternal),
+		startTimes: make(map[*viewInternal]time.Time),
+		timer:      time.NewTicker(defaultReportingDuration),
+		c:          make(chan command, 1024),
+		quit:       make(chan bool),
+		done:       make(chan bool),
+	}
+}
+
+func (w *worker) start() {
+	for {
+		select {
+		case cmd := <-w.c:
+			cmd.handleCommand(w)
+		case <-w.timer.C:
+			w.reportUsage(time.Now())
+		case <-w.quit:
+			w.timer.Stop()
+			close(w.c)
+			w.done <- true
+			return
+		}
+	}
+}
+
+func (w *worker) stop() {
+	w.quit <- true
+	<-w.done
+}
+
+func (w *worker) getMeasureRef(name string) *measureRef {
+	if mr, ok := w.measures[name]; ok {
+		return mr
+	}
+	mr := &measureRef{
+		measure: name,
+		views:   make(map[*viewInternal]struct{}),
+	}
+	w.measures[name] = mr
+	return mr
+}
+
+func (w *worker) tryRegisterView(v *View) (*viewInternal, error) {
+	vi, err := newViewInternal(v)
+	if err != nil {
+		return nil, err
+	}
+	if x, ok := w.views[vi.view.Name]; ok {
+		if !x.view.same(vi.view) {
+			return nil, fmt.Errorf("cannot subscribe view %q; a different view with the same name is already subscribed", v.Name)
+		}
+
+		// the view is already registered so there is nothing to do and the
+		// command is considered successful.
+		return x, nil
+	}
+	w.views[vi.view.Name] = vi
+	ref := w.getMeasureRef(vi.view.Measure.Name())
+	ref.views[vi] = struct{}{}
+	return vi, nil
+}
+
+func (w *worker) reportUsage(now time.Time) {
+	for _, v := range w.views {
+		if !v.isSubscribed() {
+			continue
+		}
+		rows := v.collectedRows()
+		_, ok := w.startTimes[v]
+		if !ok {
+			w.startTimes[v] = now
+		}
+		// Make sure collector is never going
+		// to mutate the exported data.
+		rows = deepCopyRowData(rows)
+		viewData := &Data{
+			View:  v.view,
+			Start: w.startTimes[v],
+			End:   time.Now(),
+			Rows:  rows,
+		}
+		exportersMu.Lock()
+		for e := range exporters {
+			e.ExportView(viewData)
+		}
+		exportersMu.Unlock()
+	}
+}
+
+func deepCopyRowData(rows []*Row) []*Row {
+	newRows := make([]*Row, 0, len(rows))
+	for _, r := range rows {
+		newRows = append(newRows, &Row{
+			Data: r.Data.clone(),
+			Tags: r.Tags,
+		})
+	}
+	return newRows
+}

--- a/vendor/go.opencensus.io/stats/view/worker_commands.go
+++ b/vendor/go.opencensus.io/stats/view/worker_commands.go
@@ -1,0 +1,171 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package view
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/internal"
+	"go.opencensus.io/tag"
+)
+
+type command interface {
+	handleCommand(w *worker)
+}
+
+// getViewByNameReq is the command to get a view given its name.
+type getViewByNameReq struct {
+	name string
+	c    chan *getViewByNameResp
+}
+
+type getViewByNameResp struct {
+	v *View
+}
+
+func (cmd *getViewByNameReq) handleCommand(w *worker) {
+	v := w.views[cmd.name]
+	if v == nil {
+		cmd.c <- &getViewByNameResp{nil}
+		return
+	}
+	cmd.c <- &getViewByNameResp{v.view}
+}
+
+// registerViewReq is the command to register a view.
+type registerViewReq struct {
+	views []*View
+	err   chan error
+}
+
+func (cmd *registerViewReq) handleCommand(w *worker) {
+	var errstr []string
+	for _, view := range cmd.views {
+		vi, err := w.tryRegisterView(view)
+		if err != nil {
+			errstr = append(errstr, fmt.Sprintf("%s: %v", view.Name, err))
+			continue
+		}
+		internal.SubscriptionReporter(view.Measure.Name())
+		vi.subscribe()
+	}
+	if len(errstr) > 0 {
+		cmd.err <- errors.New(strings.Join(errstr, "\n"))
+	} else {
+		cmd.err <- nil
+	}
+}
+
+// unregisterFromViewReq is the command to unsubscribe to a view. Has no
+// impact on the data collection for client that are pulling data from the
+// library.
+type unregisterFromViewReq struct {
+	views []string
+	done  chan struct{}
+}
+
+func (cmd *unregisterFromViewReq) handleCommand(w *worker) {
+	for _, name := range cmd.views {
+		vi, ok := w.views[name]
+		if !ok {
+			continue
+		}
+
+		vi.unsubscribe()
+		if !vi.isSubscribed() {
+			// this was the last subscription and view is not collecting anymore.
+			// The collected data can be cleared.
+			vi.clearRows()
+		}
+		delete(w.views, name)
+	}
+	cmd.done <- struct{}{}
+}
+
+// retrieveDataReq is the command to retrieve data for a view.
+type retrieveDataReq struct {
+	now time.Time
+	v   string
+	c   chan *retrieveDataResp
+}
+
+type retrieveDataResp struct {
+	rows []*Row
+	err  error
+}
+
+func (cmd *retrieveDataReq) handleCommand(w *worker) {
+	vi, ok := w.views[cmd.v]
+	if !ok {
+		cmd.c <- &retrieveDataResp{
+			nil,
+			fmt.Errorf("cannot retrieve data; view %q is not registered", cmd.v),
+		}
+		return
+	}
+
+	if !vi.isSubscribed() {
+		cmd.c <- &retrieveDataResp{
+			nil,
+			fmt.Errorf("cannot retrieve data; view %q has no subscriptions or collection is not forcibly started", cmd.v),
+		}
+		return
+	}
+	cmd.c <- &retrieveDataResp{
+		vi.collectedRows(),
+		nil,
+	}
+}
+
+// recordReq is the command to record data related to multiple measures
+// at once.
+type recordReq struct {
+	tm *tag.Map
+	ms []stats.Measurement
+}
+
+func (cmd *recordReq) handleCommand(w *worker) {
+	for _, m := range cmd.ms {
+		if (m == stats.Measurement{}) { // not subscribed
+			continue
+		}
+		ref := w.getMeasureRef(m.Measure().Name())
+		for v := range ref.views {
+			v.addSample(cmd.tm, m.Value())
+		}
+	}
+}
+
+// setReportingPeriodReq is the command to modify the duration between
+// reporting the collected data to the subscribed clients.
+type setReportingPeriodReq struct {
+	d time.Duration
+	c chan bool
+}
+
+func (cmd *setReportingPeriodReq) handleCommand(w *worker) {
+	w.timer.Stop()
+	if cmd.d <= 0 {
+		w.timer = time.NewTicker(defaultReportingDuration)
+	} else {
+		w.timer = time.NewTicker(cmd.d)
+	}
+	cmd.c <- true
+}

--- a/vendor/go.opencensus.io/tag/context.go
+++ b/vendor/go.opencensus.io/tag/context.go
@@ -1,0 +1,41 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+import "context"
+
+// FromContext returns the tag map stored in the context.
+func FromContext(ctx context.Context) *Map {
+	// The returned tag map shouldn't be mutated.
+	ts := ctx.Value(mapCtxKey)
+	if ts == nil {
+		return nil
+	}
+	return ts.(*Map)
+}
+
+// NewContext creates a new context with the given tag map.
+// To propagate a tag map to downstream methods and downstream RPCs, add a tag map
+// to the current context. NewContext will return a copy of the current context,
+// and put the tag map into the returned one.
+// If there is already a tag map in the current context, it will be replaced with m.
+func NewContext(ctx context.Context, m *Map) context.Context {
+	return context.WithValue(ctx, mapCtxKey, m)
+}
+
+type ctxKey struct{}
+
+var mapCtxKey = ctxKey{}

--- a/vendor/go.opencensus.io/tag/doc.go
+++ b/vendor/go.opencensus.io/tag/doc.go
@@ -1,0 +1,26 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+/*
+Package tag contains OpenCensus tags.
+
+Tags are key-value pairs. Tags provide additional cardinality to
+the OpenCensus instrumentation data.
+
+Tags can be propagated on the wire and in the same
+process via context.Context. Encode and Decode should be
+used to represent tags into their binary propagation form.
+*/
+package tag // import "go.opencensus.io/tag"

--- a/vendor/go.opencensus.io/tag/key.go
+++ b/vendor/go.opencensus.io/tag/key.go
@@ -1,0 +1,35 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+// Key represents a tag key.
+type Key struct {
+	name string
+}
+
+// NewKey creates or retrieves a string key identified by name.
+// Calling NewKey consequently with the same name returns the same key.
+func NewKey(name string) (Key, error) {
+	if !checkKeyName(name) {
+		return Key{}, errInvalidKeyName
+	}
+	return Key{name: name}, nil
+}
+
+// Name returns the name of the key.
+func (k Key) Name() string {
+	return k.name
+}

--- a/vendor/go.opencensus.io/tag/map.go
+++ b/vendor/go.opencensus.io/tag/map.go
@@ -1,0 +1,197 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sort"
+)
+
+// Tag is a key value pair that can be propagated on wire.
+type Tag struct {
+	Key   Key
+	Value string
+}
+
+// Map is a map of tags. Use New to create a context containing
+// a new Map.
+type Map struct {
+	m map[Key]string
+}
+
+// Value returns the value for the key if a value for the key exists.
+func (m *Map) Value(k Key) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+	v, ok := m.m[k]
+	return v, ok
+}
+
+func (m *Map) String() string {
+	if m == nil {
+		return "nil"
+	}
+	keys := make([]Key, 0, len(m.m))
+	for k := range m.m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return keys[i].Name() < keys[j].Name() })
+
+	var buffer bytes.Buffer
+	buffer.WriteString("{ ")
+	for _, k := range keys {
+		buffer.WriteString(fmt.Sprintf("{%v %v}", k.name, m.m[k]))
+	}
+	buffer.WriteString(" }")
+	return buffer.String()
+}
+
+func (m *Map) insert(k Key, v string) {
+	if _, ok := m.m[k]; ok {
+		return
+	}
+	m.m[k] = v
+}
+
+func (m *Map) update(k Key, v string) {
+	if _, ok := m.m[k]; ok {
+		m.m[k] = v
+	}
+}
+
+func (m *Map) upsert(k Key, v string) {
+	m.m[k] = v
+}
+
+func (m *Map) delete(k Key) {
+	delete(m.m, k)
+}
+
+func newMap() *Map {
+	return &Map{m: make(map[Key]string)}
+}
+
+// Mutator modifies a tag map.
+type Mutator interface {
+	Mutate(t *Map) (*Map, error)
+}
+
+// Insert returns a mutator that inserts a
+// value associated with k. If k already exists in the tag map,
+// mutator doesn't update the value.
+func Insert(k Key, v string) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			if !checkValue(v) {
+				return nil, errInvalidValue
+			}
+			m.insert(k, v)
+			return m, nil
+		},
+	}
+}
+
+// Update returns a mutator that updates the
+// value of the tag associated with k with v. If k doesn't
+// exists in the tag map, the mutator doesn't insert the value.
+func Update(k Key, v string) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			if !checkValue(v) {
+				return nil, errInvalidValue
+			}
+			m.update(k, v)
+			return m, nil
+		},
+	}
+}
+
+// Upsert returns a mutator that upserts the
+// value of the tag associated with k with v. It inserts the
+// value if k doesn't exist already. It mutates the value
+// if k already exists.
+func Upsert(k Key, v string) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			if !checkValue(v) {
+				return nil, errInvalidValue
+			}
+			m.upsert(k, v)
+			return m, nil
+		},
+	}
+}
+
+// Delete returns a mutator that deletes
+// the value associated with k.
+func Delete(k Key) Mutator {
+	return &mutator{
+		fn: func(m *Map) (*Map, error) {
+			m.delete(k)
+			return m, nil
+		},
+	}
+}
+
+// New returns a new context that contains a tag map
+// originated from the incoming context and modified
+// with the provided mutators.
+func New(ctx context.Context, mutator ...Mutator) (context.Context, error) {
+	m := newMap()
+	orig := FromContext(ctx)
+	if orig != nil {
+		for k, v := range orig.m {
+			if !checkKeyName(k.Name()) {
+				return ctx, fmt.Errorf("key:%q: %v", k, errInvalidKeyName)
+			}
+			if !checkValue(v) {
+				return ctx, fmt.Errorf("key:%q value:%q: %v", k.Name(), v, errInvalidValue)
+			}
+			m.insert(k, v)
+		}
+	}
+	var err error
+	for _, mod := range mutator {
+		m, err = mod.Mutate(m)
+		if err != nil {
+			return ctx, err
+		}
+	}
+	return NewContext(ctx, m), nil
+}
+
+// Do is similar to pprof.Do: a convenience for installing the tags
+// from the context as Go profiler labels. This allows you to
+// correlated runtime profiling with stats.
+//
+// It converts the key/values from the given map to Go profiler labels
+// and calls pprof.Do.
+//
+// Do is going to do nothing if your Go version is below 1.9.
+func Do(ctx context.Context, f func(ctx context.Context)) {
+	do(ctx, f)
+}
+
+type mutator struct {
+	fn func(t *Map) (*Map, error)
+}
+
+func (m *mutator) Mutate(t *Map) (*Map, error) {
+	return m.fn(t)
+}

--- a/vendor/go.opencensus.io/tag/map_codec.go
+++ b/vendor/go.opencensus.io/tag/map_codec.go
@@ -1,0 +1,221 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package tag
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// KeyType defines the types of keys allowed. Currently only keyTypeString is
+// supported.
+type keyType byte
+
+const (
+	keyTypeString keyType = iota
+	keyTypeInt64
+	keyTypeTrue
+	keyTypeFalse
+
+	tagsVersionID = byte(0)
+)
+
+type encoderGRPC struct {
+	buf               []byte
+	writeIdx, readIdx int
+}
+
+// writeKeyString writes the fieldID '0' followed by the key string and value
+// string.
+func (eg *encoderGRPC) writeTagString(k, v string) {
+	eg.writeByte(byte(keyTypeString))
+	eg.writeStringWithVarintLen(k)
+	eg.writeStringWithVarintLen(v)
+}
+
+func (eg *encoderGRPC) writeTagUint64(k string, i uint64) {
+	eg.writeByte(byte(keyTypeInt64))
+	eg.writeStringWithVarintLen(k)
+	eg.writeUint64(i)
+}
+
+func (eg *encoderGRPC) writeTagTrue(k string) {
+	eg.writeByte(byte(keyTypeTrue))
+	eg.writeStringWithVarintLen(k)
+}
+
+func (eg *encoderGRPC) writeTagFalse(k string) {
+	eg.writeByte(byte(keyTypeFalse))
+	eg.writeStringWithVarintLen(k)
+}
+
+func (eg *encoderGRPC) writeBytesWithVarintLen(bytes []byte) {
+	length := len(bytes)
+
+	eg.growIfRequired(binary.MaxVarintLen64 + length)
+	eg.writeIdx += binary.PutUvarint(eg.buf[eg.writeIdx:], uint64(length))
+	copy(eg.buf[eg.writeIdx:], bytes)
+	eg.writeIdx += length
+}
+
+func (eg *encoderGRPC) writeStringWithVarintLen(s string) {
+	length := len(s)
+
+	eg.growIfRequired(binary.MaxVarintLen64 + length)
+	eg.writeIdx += binary.PutUvarint(eg.buf[eg.writeIdx:], uint64(length))
+	copy(eg.buf[eg.writeIdx:], s)
+	eg.writeIdx += length
+}
+
+func (eg *encoderGRPC) writeByte(v byte) {
+	eg.growIfRequired(1)
+	eg.buf[eg.writeIdx] = v
+	eg.writeIdx++
+}
+
+func (eg *encoderGRPC) writeUint32(i uint32) {
+	eg.growIfRequired(4)
+	binary.LittleEndian.PutUint32(eg.buf[eg.writeIdx:], i)
+	eg.writeIdx += 4
+}
+
+func (eg *encoderGRPC) writeUint64(i uint64) {
+	eg.growIfRequired(8)
+	binary.LittleEndian.PutUint64(eg.buf[eg.writeIdx:], i)
+	eg.writeIdx += 8
+}
+
+func (eg *encoderGRPC) readByte() byte {
+	b := eg.buf[eg.readIdx]
+	eg.readIdx++
+	return b
+}
+
+func (eg *encoderGRPC) readUint32() uint32 {
+	i := binary.LittleEndian.Uint32(eg.buf[eg.readIdx:])
+	eg.readIdx += 4
+	return i
+}
+
+func (eg *encoderGRPC) readUint64() uint64 {
+	i := binary.LittleEndian.Uint64(eg.buf[eg.readIdx:])
+	eg.readIdx += 8
+	return i
+}
+
+func (eg *encoderGRPC) readBytesWithVarintLen() ([]byte, error) {
+	if eg.readEnded() {
+		return nil, fmt.Errorf("unexpected end while readBytesWithVarintLen '%x' starting at idx '%v'", eg.buf, eg.readIdx)
+	}
+	length, valueStart := binary.Uvarint(eg.buf[eg.readIdx:])
+	if valueStart <= 0 {
+		return nil, fmt.Errorf("unexpected end while readBytesWithVarintLen '%x' starting at idx '%v'", eg.buf, eg.readIdx)
+	}
+
+	valueStart += eg.readIdx
+	valueEnd := valueStart + int(length)
+	if valueEnd > len(eg.buf) {
+		return nil, fmt.Errorf("malformed encoding: length:%v, upper:%v, maxLength:%v", length, valueEnd, len(eg.buf))
+	}
+
+	eg.readIdx = valueEnd
+	return eg.buf[valueStart:valueEnd], nil
+}
+
+func (eg *encoderGRPC) readStringWithVarintLen() (string, error) {
+	bytes, err := eg.readBytesWithVarintLen()
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func (eg *encoderGRPC) growIfRequired(expected int) {
+	if len(eg.buf)-eg.writeIdx < expected {
+		tmp := make([]byte, 2*(len(eg.buf)+1)+expected)
+		copy(tmp, eg.buf)
+		eg.buf = tmp
+	}
+}
+
+func (eg *encoderGRPC) readEnded() bool {
+	return eg.readIdx >= len(eg.buf)
+}
+
+func (eg *encoderGRPC) bytes() []byte {
+	return eg.buf[:eg.writeIdx]
+}
+
+// Encode encodes the tag map into a []byte. It is useful to propagate
+// the tag maps on wire in binary format.
+func Encode(m *Map) []byte {
+	eg := &encoderGRPC{
+		buf: make([]byte, len(m.m)),
+	}
+	eg.writeByte(byte(tagsVersionID))
+	for k, v := range m.m {
+		eg.writeByte(byte(keyTypeString))
+		eg.writeStringWithVarintLen(k.name)
+		eg.writeBytesWithVarintLen([]byte(v))
+	}
+	return eg.bytes()
+}
+
+// Decode decodes the given []byte into a tag map.
+func Decode(bytes []byte) (*Map, error) {
+	ts := newMap()
+
+	eg := &encoderGRPC{
+		buf: bytes,
+	}
+	if len(eg.buf) == 0 {
+		return ts, nil
+	}
+
+	version := eg.readByte()
+	if version > tagsVersionID {
+		return nil, fmt.Errorf("cannot decode: unsupported version: %q; supports only up to: %q", version, tagsVersionID)
+	}
+
+	for !eg.readEnded() {
+		typ := keyType(eg.readByte())
+
+		if typ != keyTypeString {
+			return nil, fmt.Errorf("cannot decode: invalid key type: %q", typ)
+		}
+
+		k, err := eg.readBytesWithVarintLen()
+		if err != nil {
+			return nil, err
+		}
+
+		v, err := eg.readBytesWithVarintLen()
+		if err != nil {
+			return nil, err
+		}
+
+		key, err := NewKey(string(k))
+		if err != nil {
+			return nil, err // no partial failures
+		}
+		val := string(v)
+		if !checkValue(val) {
+			return nil, errInvalidValue // no partial failures
+		}
+		ts.upsert(key, val)
+	}
+	return ts, nil
+}

--- a/vendor/go.opencensus.io/tag/profile_19.go
+++ b/vendor/go.opencensus.io/tag/profile_19.go
@@ -1,0 +1,31 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.9
+
+package tag
+
+import (
+	"context"
+	"runtime/pprof"
+)
+
+func do(ctx context.Context, f func(ctx context.Context)) {
+	m := FromContext(ctx)
+	keyvals := make([]string, 0, 2*len(m.m))
+	for k, v := range m.m {
+		keyvals = append(keyvals, k.Name(), v)
+	}
+	pprof.Do(ctx, pprof.Labels(keyvals...), f)
+}

--- a/vendor/go.opencensus.io/tag/profile_not19.go
+++ b/vendor/go.opencensus.io/tag/profile_not19.go
@@ -1,0 +1,23 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.9
+
+package tag
+
+import "context"
+
+func do(ctx context.Context, f func(ctx context.Context)) {
+	f(ctx)
+}

--- a/vendor/go.opencensus.io/tag/validate.go
+++ b/vendor/go.opencensus.io/tag/validate.go
@@ -1,0 +1,56 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tag
+
+import "errors"
+
+const (
+	maxKeyLength = 255
+
+	// valid are restricted to US-ASCII subset (range 0x20 (' ') to 0x7e ('~')).
+	validKeyValueMin = 32
+	validKeyValueMax = 126
+)
+
+var (
+	errInvalidKeyName = errors.New("invalid key name: only ASCII characters accepted; max length must be 255 characters")
+	errInvalidValue   = errors.New("invalid value: only ASCII characters accepted; max length must be 255 characters")
+)
+
+func checkKeyName(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	if len(name) > maxKeyLength {
+		return false
+	}
+	return isASCII(name)
+}
+
+func isASCII(s string) bool {
+	for _, c := range s {
+		if (c < validKeyValueMin) || (c > validKeyValueMax) {
+			return false
+		}
+	}
+	return true
+}
+
+func checkValue(v string) bool {
+	if len(v) > maxKeyLength {
+		return false
+	}
+	return isASCII(v)
+}

--- a/vendor/go.opencensus.io/trace/basetypes.go
+++ b/vendor/go.opencensus.io/trace/basetypes.go
@@ -1,0 +1,114 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"fmt"
+	"time"
+)
+
+type (
+	// TraceID is a 16-byte identifier for a set of spans.
+	TraceID [16]byte
+
+	// SpanID is an 8-byte identifier for a single span.
+	SpanID [8]byte
+)
+
+func (t TraceID) String() string {
+	return fmt.Sprintf("%02x", t[:])
+}
+
+func (s SpanID) String() string {
+	return fmt.Sprintf("%02x", s[:])
+}
+
+// Annotation represents a text annotation with a set of attributes and a timestamp.
+type Annotation struct {
+	Time       time.Time
+	Message    string
+	Attributes map[string]interface{}
+}
+
+// Attribute represents a key-value pair on a span, link or annotation.
+// Construct with one of: BoolAttribute, Int64Attribute, or StringAttribute.
+type Attribute struct {
+	key   string
+	value interface{}
+}
+
+// BoolAttribute returns a bool-valued attribute.
+func BoolAttribute(key string, value bool) Attribute {
+	return Attribute{key: key, value: value}
+}
+
+// Int64Attribute returns an int64-valued attribute.
+func Int64Attribute(key string, value int64) Attribute {
+	return Attribute{key: key, value: value}
+}
+
+// StringAttribute returns a string-valued attribute.
+func StringAttribute(key string, value string) Attribute {
+	return Attribute{key: key, value: value}
+}
+
+// LinkType specifies the relationship between the span that had the link
+// added, and the linked span.
+type LinkType int32
+
+// LinkType values.
+const (
+	LinkTypeUnspecified LinkType = iota // The relationship of the two spans is unknown.
+	LinkTypeChild                       // The current span is a child of the linked span.
+	LinkTypeParent                      // The current span is the parent of the linked span.
+)
+
+// Link represents a reference from one span to another span.
+type Link struct {
+	TraceID TraceID
+	SpanID  SpanID
+	Type    LinkType
+	// Attributes is a set of attributes on the link.
+	Attributes map[string]interface{}
+}
+
+// MessageEventType specifies the type of message event.
+type MessageEventType int32
+
+// MessageEventType values.
+const (
+	MessageEventTypeUnspecified MessageEventType = iota // Unknown event type.
+	MessageEventTypeSent                                // Indicates a sent RPC message.
+	MessageEventTypeRecv                                // Indicates a received RPC message.
+)
+
+// MessageEvent represents an event describing a message sent or received on the network.
+type MessageEvent struct {
+	Time                 time.Time
+	EventType            MessageEventType
+	MessageID            int64
+	UncompressedByteSize int64
+	CompressedByteSize   int64
+}
+
+// Status is the status of a Span.
+type Status struct {
+	// Code is a status code.  Zero indicates success.
+	//
+	// If Code will be propagated to Google APIs, it ideally should be a value from
+	// https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto .
+	Code    int32
+	Message string
+}

--- a/vendor/go.opencensus.io/trace/config.go
+++ b/vendor/go.opencensus.io/trace/config.go
@@ -1,0 +1,40 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import "go.opencensus.io/trace/internal"
+
+// Config represents the global tracing configuration.
+type Config struct {
+	// DefaultSampler is the default sampler used when creating new spans.
+	DefaultSampler Sampler
+
+	// IDGenerator is for internal use only.
+	IDGenerator internal.IDGenerator
+}
+
+// ApplyConfig applies changes to the global tracing configuration.
+//
+// Fields not provided in the given config are going to be preserved.
+func ApplyConfig(cfg Config) {
+	c := *config.Load().(*Config)
+	if cfg.DefaultSampler != nil {
+		c.DefaultSampler = cfg.DefaultSampler
+	}
+	if cfg.IDGenerator != nil {
+		c.IDGenerator = cfg.IDGenerator
+	}
+	config.Store(&c)
+}

--- a/vendor/go.opencensus.io/trace/doc.go
+++ b/vendor/go.opencensus.io/trace/doc.go
@@ -1,0 +1,51 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*
+Package trace contains support for OpenCensus distributed tracing.
+
+The following assumes a basic familiarity with OpenCensus concepts.
+See http://opencensus.io
+
+
+Exporting Traces
+
+To export collected tracing data, register at least one exporter. You can use
+one of the provided exporters or write your own.
+
+    trace.RegisterExporter(exporter)
+
+By default, traces will be sampled relatively rarely. To change the sampling
+frequency for your entire program, call ApplyConfig. Use a ProbabilitySampler
+to sample a subset of traces, or use AlwaysSample to collect a trace on every run:
+
+    trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+
+Adding Spans to a Trace
+
+A trace consists of a tree of spans. In Go, the current span is carried in a
+context.Context.
+
+It is common to want to capture all the activity of a function call in a span. For
+this to work, the function must take a context.Context as a parameter. Add these two
+lines to the top of the function:
+
+    ctx, span := trace.StartSpan(ctx, "my.org/Run")
+    defer span.End()
+
+StartSpan will create a new top-level span if the context
+doesn't contain another span, otherwise it will create a child span.
+*/
+package trace // import "go.opencensus.io/trace"

--- a/vendor/go.opencensus.io/trace/export.go
+++ b/vendor/go.opencensus.io/trace/export.go
@@ -1,0 +1,76 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"sync"
+	"time"
+)
+
+// Exporter is a type for functions that receive sampled trace spans.
+//
+// The ExportSpan method should be safe for concurrent use and should return
+// quickly; if an Exporter takes a significant amount of time to process a
+// SpanData, that work should be done on another goroutine.
+//
+// The SpanData should not be modified, but a pointer to it can be kept.
+type Exporter interface {
+	ExportSpan(s *SpanData)
+}
+
+var (
+	exportersMu sync.Mutex
+	exporters   map[Exporter]struct{}
+)
+
+// RegisterExporter adds to the list of Exporters that will receive sampled
+// trace spans.
+//
+// Binaries can register exporters, libraries shouldn't register exporters.
+func RegisterExporter(e Exporter) {
+	exportersMu.Lock()
+	if exporters == nil {
+		exporters = make(map[Exporter]struct{})
+	}
+	exporters[e] = struct{}{}
+	exportersMu.Unlock()
+}
+
+// UnregisterExporter removes from the list of Exporters the Exporter that was
+// registered with the given name.
+func UnregisterExporter(e Exporter) {
+	exportersMu.Lock()
+	delete(exporters, e)
+	exportersMu.Unlock()
+}
+
+// SpanData contains all the information collected by a Span.
+type SpanData struct {
+	SpanContext
+	ParentSpanID SpanID
+	SpanKind     int
+	Name         string
+	StartTime    time.Time
+	// The wall clock time of EndTime will be adjusted to always be offset
+	// from StartTime by the duration of the span.
+	EndTime time.Time
+	// The values of Attributes each have type string, bool, or int64.
+	Attributes    map[string]interface{}
+	Annotations   []Annotation
+	MessageEvents []MessageEvent
+	Status
+	Links           []Link
+	HasRemoteParent bool
+}

--- a/vendor/go.opencensus.io/trace/internal/internal.go
+++ b/vendor/go.opencensus.io/trace/internal/internal.go
@@ -1,0 +1,21 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package internal provides trace internals.
+package internal
+
+type IDGenerator interface {
+	NewTraceID() [16]byte
+	NewSpanID() [8]byte
+}

--- a/vendor/go.opencensus.io/trace/propagation/propagation.go
+++ b/vendor/go.opencensus.io/trace/propagation/propagation.go
@@ -1,0 +1,108 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package propagation implements the binary trace context format.
+package propagation // import "go.opencensus.io/trace/propagation"
+
+// TODO: link to external spec document.
+
+// BinaryFormat format:
+//
+// Binary value: <version_id><version_format>
+// version_id: 1 byte representing the version id.
+//
+// For version_id = 0:
+//
+// version_format: <field><field>
+// field_format: <field_id><field_format>
+//
+// Fields:
+//
+// TraceId: (field_id = 0, len = 16, default = "0000000000000000") - 16-byte array representing the trace_id.
+// SpanId: (field_id = 1, len = 8, default = "00000000") - 8-byte array representing the span_id.
+// TraceOptions: (field_id = 2, len = 1, default = "0") - 1-byte array representing the trace_options.
+//
+// Fields MUST be encoded using the field id order (smaller to higher).
+//
+// Valid value example:
+//
+// {0, 0, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 1, 97,
+// 98, 99, 100, 101, 102, 103, 104, 2, 1}
+//
+// version_id = 0;
+// trace_id = {64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}
+// span_id = {97, 98, 99, 100, 101, 102, 103, 104};
+// trace_options = {1};
+
+import (
+	"net/http"
+
+	"go.opencensus.io/trace"
+)
+
+// Binary returns the binary format representation of a SpanContext.
+//
+// If sc is the zero value, Binary returns nil.
+func Binary(sc trace.SpanContext) []byte {
+	if sc == (trace.SpanContext{}) {
+		return nil
+	}
+	var b [29]byte
+	copy(b[2:18], sc.TraceID[:])
+	b[18] = 1
+	copy(b[19:27], sc.SpanID[:])
+	b[27] = 2
+	b[28] = uint8(sc.TraceOptions)
+	return b[:]
+}
+
+// FromBinary returns the SpanContext represented by b.
+//
+// If b has an unsupported version ID or contains no TraceID, FromBinary
+// returns with ok==false.
+func FromBinary(b []byte) (sc trace.SpanContext, ok bool) {
+	if len(b) == 0 || b[0] != 0 {
+		return trace.SpanContext{}, false
+	}
+	b = b[1:]
+	if len(b) >= 17 && b[0] == 0 {
+		copy(sc.TraceID[:], b[1:17])
+		b = b[17:]
+	} else {
+		return trace.SpanContext{}, false
+	}
+	if len(b) >= 9 && b[0] == 1 {
+		copy(sc.SpanID[:], b[1:9])
+		b = b[9:]
+	}
+	if len(b) >= 2 && b[0] == 2 {
+		sc.TraceOptions = trace.TraceOptions(b[1])
+	}
+	return sc, true
+}
+
+// HTTPFormat implementations propagate span contexts
+// in HTTP requests.
+//
+// SpanContextFromRequest extracts a span context from incoming
+// requests.
+//
+// SpanContextToRequest modifies the given request to include the given
+// span context.
+type HTTPFormat interface {
+	SpanContextFromRequest(req *http.Request) (sc trace.SpanContext, ok bool)
+	SpanContextToRequest(sc trace.SpanContext, req *http.Request)
+}
+
+// TODO(jbd): Find a more representative but short name for HTTPFormat.

--- a/vendor/go.opencensus.io/trace/sampling.go
+++ b/vendor/go.opencensus.io/trace/sampling.go
@@ -1,0 +1,76 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"encoding/binary"
+)
+
+const defaultSamplingProbability = 1e-4
+
+func newDefaultSampler() Sampler {
+	return ProbabilitySampler(defaultSamplingProbability)
+}
+
+// Sampler decides whether a trace should be sampled and exported.
+type Sampler func(SamplingParameters) SamplingDecision
+
+// SamplingParameters contains the values passed to a Sampler.
+type SamplingParameters struct {
+	ParentContext   SpanContext
+	TraceID         TraceID
+	SpanID          SpanID
+	Name            string
+	HasRemoteParent bool
+}
+
+// SamplingDecision is the value returned by a Sampler.
+type SamplingDecision struct {
+	Sample bool
+}
+
+// ProbabilitySampler returns a Sampler that samples a given fraction of traces.
+//
+// It also samples spans whose parents are sampled.
+func ProbabilitySampler(fraction float64) Sampler {
+	if !(fraction >= 0) {
+		fraction = 0
+	} else if fraction >= 1 {
+		return AlwaysSample()
+	}
+
+	traceIDUpperBound := uint64(fraction * (1 << 63))
+	return Sampler(func(p SamplingParameters) SamplingDecision {
+		if p.ParentContext.IsSampled() {
+			return SamplingDecision{Sample: true}
+		}
+		x := binary.BigEndian.Uint64(p.TraceID[0:8]) >> 1
+		return SamplingDecision{Sample: x < traceIDUpperBound}
+	})
+}
+
+// AlwaysSample returns a Sampler that samples every trace.
+func AlwaysSample() Sampler {
+	return func(p SamplingParameters) SamplingDecision {
+		return SamplingDecision{Sample: true}
+	}
+}
+
+// NeverSample returns a Sampler that samples no traces.
+func NeverSample() Sampler {
+	return func(p SamplingParameters) SamplingDecision {
+		return SamplingDecision{Sample: false}
+	}
+}

--- a/vendor/go.opencensus.io/trace/spanbucket.go
+++ b/vendor/go.opencensus.io/trace/spanbucket.go
@@ -1,0 +1,130 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"time"
+)
+
+// samplePeriod is the minimum time between accepting spans in a single bucket.
+const samplePeriod = time.Second
+
+// defaultLatencies contains the default latency bucket bounds.
+// TODO: consider defaults, make configurable
+var defaultLatencies = [...]time.Duration{
+	10 * time.Microsecond,
+	100 * time.Microsecond,
+	time.Millisecond,
+	10 * time.Millisecond,
+	100 * time.Millisecond,
+	time.Second,
+	10 * time.Second,
+	time.Minute,
+}
+
+// bucket is a container for a set of spans for a particular error code or latency range.
+type bucket struct {
+	nextTime  time.Time   // next time we can accept a span
+	buffer    []*SpanData // circular buffer of spans
+	nextIndex int         // location next SpanData should be placed in buffer
+	overflow  bool        // whether the circular buffer has wrapped around
+}
+
+func makeBucket(bufferSize int) bucket {
+	return bucket{
+		buffer: make([]*SpanData, bufferSize),
+	}
+}
+
+// add adds a span to the bucket, if nextTime has been reached.
+func (b *bucket) add(s *SpanData) {
+	if s.EndTime.Before(b.nextTime) {
+		return
+	}
+	if len(b.buffer) == 0 {
+		return
+	}
+	b.nextTime = s.EndTime.Add(samplePeriod)
+	b.buffer[b.nextIndex] = s
+	b.nextIndex++
+	if b.nextIndex == len(b.buffer) {
+		b.nextIndex = 0
+		b.overflow = true
+	}
+}
+
+// size returns the number of spans in the bucket.
+func (b *bucket) size() int {
+	if b.overflow {
+		return len(b.buffer)
+	}
+	return b.nextIndex
+}
+
+// span returns the ith span in the bucket.
+func (b *bucket) span(i int) *SpanData {
+	if !b.overflow {
+		return b.buffer[i]
+	}
+	if i < len(b.buffer)-b.nextIndex {
+		return b.buffer[b.nextIndex+i]
+	}
+	return b.buffer[b.nextIndex+i-len(b.buffer)]
+}
+
+// resize changes the size of the bucket to n, keeping up to n existing spans.
+func (b *bucket) resize(n int) {
+	cur := b.size()
+	newBuffer := make([]*SpanData, n)
+	if cur < n {
+		for i := 0; i < cur; i++ {
+			newBuffer[i] = b.span(i)
+		}
+		b.buffer = newBuffer
+		b.nextIndex = cur
+		b.overflow = false
+		return
+	}
+	for i := 0; i < n; i++ {
+		newBuffer[i] = b.span(i + cur - n)
+	}
+	b.buffer = newBuffer
+	b.nextIndex = 0
+	b.overflow = true
+}
+
+// latencyBucket returns the appropriate bucket number for a given latency.
+func latencyBucket(latency time.Duration) int {
+	i := 0
+	for i < len(defaultLatencies) && latency >= defaultLatencies[i] {
+		i++
+	}
+	return i
+}
+
+// latencyBucketBounds returns the lower and upper bounds for a latency bucket
+// number.
+//
+// The lower bound is inclusive, the upper bound is exclusive (except for the
+// last bucket.)
+func latencyBucketBounds(index int) (lower time.Duration, upper time.Duration) {
+	if index == 0 {
+		return 0, defaultLatencies[index]
+	}
+	if index == len(defaultLatencies) {
+		return defaultLatencies[index-1], 1<<63 - 1
+	}
+	return defaultLatencies[index-1], defaultLatencies[index]
+}

--- a/vendor/go.opencensus.io/trace/spanstore.go
+++ b/vendor/go.opencensus.io/trace/spanstore.go
@@ -1,0 +1,306 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"sync"
+	"time"
+
+	"go.opencensus.io/internal"
+)
+
+const (
+	maxBucketSize     = 100000
+	defaultBucketSize = 10
+)
+
+var (
+	ssmu       sync.RWMutex // protects spanStores
+	spanStores = make(map[string]*spanStore)
+)
+
+// This exists purely to avoid exposing internal methods used by z-Pages externally.
+type internalOnly struct{}
+
+func init() {
+	//TODO(#412): remove
+	internal.Trace = &internalOnly{}
+}
+
+// ReportActiveSpans returns the active spans for the given name.
+func (i internalOnly) ReportActiveSpans(name string) []*SpanData {
+	s := spanStoreForName(name)
+	if s == nil {
+		return nil
+	}
+	var out []*SpanData
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for span := range s.active {
+		out = append(out, span.makeSpanData())
+	}
+	return out
+}
+
+// ReportSpansByError returns a sample of error spans.
+//
+// If code is nonzero, only spans with that status code are returned.
+func (i internalOnly) ReportSpansByError(name string, code int32) []*SpanData {
+	s := spanStoreForName(name)
+	if s == nil {
+		return nil
+	}
+	var out []*SpanData
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if code != 0 {
+		if b, ok := s.errors[code]; ok {
+			for _, sd := range b.buffer {
+				if sd == nil {
+					break
+				}
+				out = append(out, sd)
+			}
+		}
+	} else {
+		for _, b := range s.errors {
+			for _, sd := range b.buffer {
+				if sd == nil {
+					break
+				}
+				out = append(out, sd)
+			}
+		}
+	}
+	return out
+}
+
+// ConfigureBucketSizes sets the number of spans to keep per latency and error
+// bucket for different span names.
+func (i internalOnly) ConfigureBucketSizes(bcs []internal.BucketConfiguration) {
+	for _, bc := range bcs {
+		latencyBucketSize := bc.MaxRequestsSucceeded
+		if latencyBucketSize < 0 {
+			latencyBucketSize = 0
+		}
+		if latencyBucketSize > maxBucketSize {
+			latencyBucketSize = maxBucketSize
+		}
+		errorBucketSize := bc.MaxRequestsErrors
+		if errorBucketSize < 0 {
+			errorBucketSize = 0
+		}
+		if errorBucketSize > maxBucketSize {
+			errorBucketSize = maxBucketSize
+		}
+		spanStoreSetSize(bc.Name, latencyBucketSize, errorBucketSize)
+	}
+}
+
+// ReportSpansPerMethod returns a summary of what spans are being stored for each span name.
+func (i internalOnly) ReportSpansPerMethod() map[string]internal.PerMethodSummary {
+	out := make(map[string]internal.PerMethodSummary)
+	ssmu.RLock()
+	defer ssmu.RUnlock()
+	for name, s := range spanStores {
+		s.mu.Lock()
+		p := internal.PerMethodSummary{
+			Active: len(s.active),
+		}
+		for code, b := range s.errors {
+			p.ErrorBuckets = append(p.ErrorBuckets, internal.ErrorBucketSummary{
+				ErrorCode: code,
+				Size:      b.size(),
+			})
+		}
+		for i, b := range s.latency {
+			min, max := latencyBucketBounds(i)
+			p.LatencyBuckets = append(p.LatencyBuckets, internal.LatencyBucketSummary{
+				MinLatency: min,
+				MaxLatency: max,
+				Size:       b.size(),
+			})
+		}
+		s.mu.Unlock()
+		out[name] = p
+	}
+	return out
+}
+
+// ReportSpansByLatency returns a sample of successful spans.
+//
+// minLatency is the minimum latency of spans to be returned.
+// maxLatency, if nonzero, is the maximum latency of spans to be returned.
+func (i internalOnly) ReportSpansByLatency(name string, minLatency, maxLatency time.Duration) []*SpanData {
+	s := spanStoreForName(name)
+	if s == nil {
+		return nil
+	}
+	var out []*SpanData
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i, b := range s.latency {
+		min, max := latencyBucketBounds(i)
+		if i+1 != len(s.latency) && max <= minLatency {
+			continue
+		}
+		if maxLatency != 0 && maxLatency < min {
+			continue
+		}
+		for _, sd := range b.buffer {
+			if sd == nil {
+				break
+			}
+			if minLatency != 0 || maxLatency != 0 {
+				d := sd.EndTime.Sub(sd.StartTime)
+				if d < minLatency {
+					continue
+				}
+				if maxLatency != 0 && d > maxLatency {
+					continue
+				}
+			}
+			out = append(out, sd)
+		}
+	}
+	return out
+}
+
+// spanStore keeps track of spans stored for a particular span name.
+//
+// It contains all active spans; a sample of spans for failed requests,
+// categorized by error code; and a sample of spans for successful requests,
+// bucketed by latency.
+type spanStore struct {
+	mu                     sync.Mutex // protects everything below.
+	active                 map[*Span]struct{}
+	errors                 map[int32]*bucket
+	latency                []bucket
+	maxSpansPerErrorBucket int
+}
+
+// newSpanStore creates a span store.
+func newSpanStore(name string, latencyBucketSize int, errorBucketSize int) *spanStore {
+	s := &spanStore{
+		active:                 make(map[*Span]struct{}),
+		latency:                make([]bucket, len(defaultLatencies)+1),
+		maxSpansPerErrorBucket: errorBucketSize,
+	}
+	for i := range s.latency {
+		s.latency[i] = makeBucket(latencyBucketSize)
+	}
+	return s
+}
+
+// spanStoreForName returns the spanStore for the given name.
+//
+// It returns nil if it doesn't exist.
+func spanStoreForName(name string) *spanStore {
+	var s *spanStore
+	ssmu.RLock()
+	s, _ = spanStores[name]
+	ssmu.RUnlock()
+	return s
+}
+
+// spanStoreForNameCreateIfNew returns the spanStore for the given name.
+//
+// It creates it if it didn't exist.
+func spanStoreForNameCreateIfNew(name string) *spanStore {
+	ssmu.RLock()
+	s, ok := spanStores[name]
+	ssmu.RUnlock()
+	if ok {
+		return s
+	}
+	ssmu.Lock()
+	defer ssmu.Unlock()
+	s, ok = spanStores[name]
+	if ok {
+		return s
+	}
+	s = newSpanStore(name, defaultBucketSize, defaultBucketSize)
+	spanStores[name] = s
+	return s
+}
+
+// spanStoreSetSize resizes the spanStore for the given name.
+//
+// It creates it if it didn't exist.
+func spanStoreSetSize(name string, latencyBucketSize int, errorBucketSize int) {
+	ssmu.RLock()
+	s, ok := spanStores[name]
+	ssmu.RUnlock()
+	if ok {
+		s.resize(latencyBucketSize, errorBucketSize)
+		return
+	}
+	ssmu.Lock()
+	defer ssmu.Unlock()
+	s, ok = spanStores[name]
+	if ok {
+		s.resize(latencyBucketSize, errorBucketSize)
+		return
+	}
+	s = newSpanStore(name, latencyBucketSize, errorBucketSize)
+	spanStores[name] = s
+}
+
+func (s *spanStore) resize(latencyBucketSize int, errorBucketSize int) {
+	s.mu.Lock()
+	for i := range s.latency {
+		s.latency[i].resize(latencyBucketSize)
+	}
+	for _, b := range s.errors {
+		b.resize(errorBucketSize)
+	}
+	s.maxSpansPerErrorBucket = errorBucketSize
+	s.mu.Unlock()
+}
+
+// add adds a span to the active bucket of the spanStore.
+func (s *spanStore) add(span *Span) {
+	s.mu.Lock()
+	s.active[span] = struct{}{}
+	s.mu.Unlock()
+}
+
+// finished removes a span from the active set, and adds a corresponding
+// SpanData to a latency or error bucket.
+func (s *spanStore) finished(span *Span, sd *SpanData) {
+	latency := sd.EndTime.Sub(sd.StartTime)
+	if latency < 0 {
+		latency = 0
+	}
+	code := sd.Status.Code
+
+	s.mu.Lock()
+	delete(s.active, span)
+	if code == 0 {
+		s.latency[latencyBucket(latency)].add(sd)
+	} else {
+		if s.errors == nil {
+			s.errors = make(map[int32]*bucket)
+		}
+		if b := s.errors[code]; b != nil {
+			b.add(sd)
+		} else {
+			b := makeBucket(s.maxSpansPerErrorBucket)
+			s.errors[code] = &b
+			b.add(sd)
+		}
+	}
+	s.mu.Unlock()
+}

--- a/vendor/go.opencensus.io/trace/status_codes.go
+++ b/vendor/go.opencensus.io/trace/status_codes.go
@@ -1,0 +1,37 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+// Status codes for use with Span.SetStatus. These correspond to the status
+// codes used by gRPC defined here: https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+const (
+	StatusCodeOK                 = 0
+	StatusCodeCancelled          = 1
+	StatusCodeUnknown            = 2
+	StatusCodeInvalidArgument    = 3
+	StatusCodeDeadlineExceeded   = 4
+	StatusCodeNotFound           = 5
+	StatusCodeAlreadyExists      = 6
+	StatusCodePermissionDenied   = 7
+	StatusCodeResourceExhausted  = 8
+	StatusCodeFailedPrecondition = 9
+	StatusCodeAborted            = 10
+	StatusCodeOutOfRange         = 11
+	StatusCodeUnimplemented      = 12
+	StatusCodeInternal           = 13
+	StatusCodeUnavailable        = 14
+	StatusCodeDataLoss           = 15
+	StatusCodeUnauthenticated    = 16
+)

--- a/vendor/go.opencensus.io/trace/trace.go
+++ b/vendor/go.opencensus.io/trace/trace.go
@@ -1,0 +1,516 @@
+// Copyright 2017, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trace
+
+import (
+	"context"
+	crand "crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.opencensus.io/internal"
+)
+
+// Span represents a span of a trace.  It has an associated SpanContext, and
+// stores data accumulated while the span is active.
+//
+// Ideally users should interact with Spans by calling the functions in this
+// package that take a Context parameter.
+type Span struct {
+	// data contains information recorded about the span.
+	//
+	// It will be non-nil if we are exporting the span or recording events for it.
+	// Otherwise, data is nil, and the Span is simply a carrier for the
+	// SpanContext, so that the trace ID is propagated.
+	data        *SpanData
+	mu          sync.Mutex // protects the contents of *data (but not the pointer value.)
+	spanContext SpanContext
+	// spanStore is the spanStore this span belongs to, if any, otherwise it is nil.
+	*spanStore
+	endOnce sync.Once
+
+	executionTracerTaskEnd func() // ends the execution tracer span
+}
+
+// IsRecordingEvents returns true if events are being recorded for this span.
+// Use this check to avoid computing expensive annotations when they will never
+// be used.
+func (s *Span) IsRecordingEvents() bool {
+	if s == nil {
+		return false
+	}
+	return s.data != nil
+}
+
+// TraceOptions contains options associated with a trace span.
+type TraceOptions uint32
+
+// IsSampled returns true if the span will be exported.
+func (sc SpanContext) IsSampled() bool {
+	return sc.TraceOptions.IsSampled()
+}
+
+// setIsSampled sets the TraceOptions bit that determines whether the span will be exported.
+func (sc *SpanContext) setIsSampled(sampled bool) {
+	if sampled {
+		sc.TraceOptions |= 1
+	} else {
+		sc.TraceOptions &= ^TraceOptions(1)
+	}
+}
+
+// IsSampled returns true if the span will be exported.
+func (t TraceOptions) IsSampled() bool {
+	return t&1 == 1
+}
+
+// SpanContext contains the state that must propagate across process boundaries.
+//
+// SpanContext is not an implementation of context.Context.
+// TODO: add reference to external Census docs for SpanContext.
+type SpanContext struct {
+	TraceID      TraceID
+	SpanID       SpanID
+	TraceOptions TraceOptions
+}
+
+type contextKey struct{}
+
+// FromContext returns the Span stored in a context, or nil if there isn't one.
+func FromContext(ctx context.Context) *Span {
+	s, _ := ctx.Value(contextKey{}).(*Span)
+	return s
+}
+
+// WithSpan returns a new context with the given Span attached.
+//
+// Deprecated: Use NewContext.
+func WithSpan(parent context.Context, s *Span) context.Context {
+	return NewContext(parent, s)
+}
+
+// NewContext returns a new context with the given Span attached.
+func NewContext(parent context.Context, s *Span) context.Context {
+	return context.WithValue(parent, contextKey{}, s)
+}
+
+// All available span kinds. Span kind must be either one of these values.
+const (
+	SpanKindUnspecified = iota
+	SpanKindServer
+	SpanKindClient
+)
+
+// StartOptions contains options concerning how a span is started.
+type StartOptions struct {
+	// Sampler to consult for this Span. If provided, it is always consulted.
+	//
+	// If not provided, then the behavior differs based on whether
+	// the parent of this Span is remote, local, or there is no parent.
+	// In the case of a remote parent or no parent, the
+	// default sampler (see Config) will be consulted. Otherwise,
+	// when there is a non-remote parent, no new sampling decision will be made:
+	// we will preserve the sampling of the parent.
+	Sampler Sampler
+
+	// SpanKind represents the kind of a span. If none is set,
+	// SpanKindUnspecified is used.
+	SpanKind int
+}
+
+// StartOption apply changes to StartOptions.
+type StartOption func(*StartOptions)
+
+// WithSpanKind makes new spans to be created with the given kind.
+func WithSpanKind(spanKind int) StartOption {
+	return func(o *StartOptions) {
+		o.SpanKind = spanKind
+	}
+}
+
+// WithSampler makes new spans to be be created with a custom sampler.
+// Otherwise, the global sampler is used.
+func WithSampler(sampler Sampler) StartOption {
+	return func(o *StartOptions) {
+		o.Sampler = sampler
+	}
+}
+
+// StartSpan starts a new child span of the current span in the context. If
+// there is no span in the context, creates a new trace and span.
+func StartSpan(ctx context.Context, name string, o ...StartOption) (context.Context, *Span) {
+	var opts StartOptions
+	var parent SpanContext
+	if p := FromContext(ctx); p != nil {
+		parent = p.spanContext
+	}
+	for _, op := range o {
+		op(&opts)
+	}
+	span := startSpanInternal(name, parent != SpanContext{}, parent, false, opts)
+
+	ctx, end := startExecutionTracerTask(ctx, name)
+	span.executionTracerTaskEnd = end
+	return NewContext(ctx, span), span
+}
+
+// StartSpanWithRemoteParent starts a new child span of the span from the given parent.
+//
+// If the incoming context contains a parent, it ignores. StartSpanWithRemoteParent is
+// preferred for cases where the parent is propagated via an incoming request.
+func StartSpanWithRemoteParent(ctx context.Context, name string, parent SpanContext, o ...StartOption) (context.Context, *Span) {
+	var opts StartOptions
+	for _, op := range o {
+		op(&opts)
+	}
+	span := startSpanInternal(name, parent != SpanContext{}, parent, true, opts)
+	ctx, end := startExecutionTracerTask(ctx, name)
+	span.executionTracerTaskEnd = end
+	return NewContext(ctx, span), span
+}
+
+// NewSpan returns a new span.
+//
+// If parent is not nil, created span will be a child of the parent.
+//
+// Deprecated: Use StartSpan.
+func NewSpan(name string, parent *Span, o StartOptions) *Span {
+	var parentSpanContext SpanContext
+	if parent != nil {
+		parentSpanContext = parent.SpanContext()
+	}
+	return startSpanInternal(name, parent != nil, parentSpanContext, false, o)
+}
+
+// NewSpanWithRemoteParent returns a new span with the given parent SpanContext.
+//
+// Deprecated: Use StartSpanWithRemoteParent.
+func NewSpanWithRemoteParent(name string, parent SpanContext, o StartOptions) *Span {
+	return startSpanInternal(name, true, parent, true, o)
+}
+
+func startSpanInternal(name string, hasParent bool, parent SpanContext, remoteParent bool, o StartOptions) *Span {
+	span := &Span{}
+	span.spanContext = parent
+
+	cfg := config.Load().(*Config)
+
+	if !hasParent {
+		span.spanContext.TraceID = cfg.IDGenerator.NewTraceID()
+	}
+	span.spanContext.SpanID = cfg.IDGenerator.NewSpanID()
+	sampler := cfg.DefaultSampler
+
+	if !hasParent || remoteParent || o.Sampler != nil {
+		// If this span is the child of a local span and no Sampler is set in the
+		// options, keep the parent's TraceOptions.
+		//
+		// Otherwise, consult the Sampler in the options if it is non-nil, otherwise
+		// the default sampler.
+		if o.Sampler != nil {
+			sampler = o.Sampler
+		}
+		span.spanContext.setIsSampled(sampler(SamplingParameters{
+			ParentContext:   parent,
+			TraceID:         span.spanContext.TraceID,
+			SpanID:          span.spanContext.SpanID,
+			Name:            name,
+			HasRemoteParent: remoteParent}).Sample)
+	}
+
+	if !internal.LocalSpanStoreEnabled && !span.spanContext.IsSampled() {
+		return span
+	}
+
+	span.data = &SpanData{
+		SpanContext:     span.spanContext,
+		StartTime:       time.Now(),
+		SpanKind:        o.SpanKind,
+		Name:            name,
+		HasRemoteParent: remoteParent,
+	}
+	if hasParent {
+		span.data.ParentSpanID = parent.SpanID
+	}
+	if internal.LocalSpanStoreEnabled {
+		var ss *spanStore
+		ss = spanStoreForNameCreateIfNew(name)
+		if ss != nil {
+			span.spanStore = ss
+			ss.add(span)
+		}
+	}
+
+	return span
+}
+
+// End ends the span.
+func (s *Span) End() {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	s.endOnce.Do(func() {
+		if s.executionTracerTaskEnd != nil {
+			s.executionTracerTaskEnd()
+		}
+		// TODO: optimize to avoid this call if sd won't be used.
+		sd := s.makeSpanData()
+		sd.EndTime = internal.MonotonicEndTime(sd.StartTime)
+		if s.spanStore != nil {
+			s.spanStore.finished(s, sd)
+		}
+		if s.spanContext.IsSampled() {
+			// TODO: consider holding exportersMu for less time.
+			exportersMu.Lock()
+			for e := range exporters {
+				e.ExportSpan(sd)
+			}
+			exportersMu.Unlock()
+		}
+	})
+}
+
+// makeSpanData produces a SpanData representing the current state of the Span.
+// It requires that s.data is non-nil.
+func (s *Span) makeSpanData() *SpanData {
+	var sd SpanData
+	s.mu.Lock()
+	sd = *s.data
+	if s.data.Attributes != nil {
+		sd.Attributes = make(map[string]interface{})
+		for k, v := range s.data.Attributes {
+			sd.Attributes[k] = v
+		}
+	}
+	s.mu.Unlock()
+	return &sd
+}
+
+// SpanContext returns the SpanContext of the span.
+func (s *Span) SpanContext() SpanContext {
+	if s == nil {
+		return SpanContext{}
+	}
+	return s.spanContext
+}
+
+// SetStatus sets the status of the span, if it is recording events.
+func (s *Span) SetStatus(status Status) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	s.mu.Lock()
+	s.data.Status = status
+	s.mu.Unlock()
+}
+
+// AddAttributes sets attributes in the span.
+//
+// Existing attributes whose keys appear in the attributes parameter are overwritten.
+func (s *Span) AddAttributes(attributes ...Attribute) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	s.mu.Lock()
+	if s.data.Attributes == nil {
+		s.data.Attributes = make(map[string]interface{})
+	}
+	copyAttributes(s.data.Attributes, attributes)
+	s.mu.Unlock()
+}
+
+// copyAttributes copies a slice of Attributes into a map.
+func copyAttributes(m map[string]interface{}, attributes []Attribute) {
+	for _, a := range attributes {
+		m[a.key] = a.value
+	}
+}
+
+func (s *Span) lazyPrintfInternal(attributes []Attribute, format string, a ...interface{}) {
+	now := time.Now()
+	msg := fmt.Sprintf(format, a...)
+	var m map[string]interface{}
+	s.mu.Lock()
+	if len(attributes) != 0 {
+		m = make(map[string]interface{})
+		copyAttributes(m, attributes)
+	}
+	s.data.Annotations = append(s.data.Annotations, Annotation{
+		Time:       now,
+		Message:    msg,
+		Attributes: m,
+	})
+	s.mu.Unlock()
+}
+
+func (s *Span) printStringInternal(attributes []Attribute, str string) {
+	now := time.Now()
+	var a map[string]interface{}
+	s.mu.Lock()
+	if len(attributes) != 0 {
+		a = make(map[string]interface{})
+		copyAttributes(a, attributes)
+	}
+	s.data.Annotations = append(s.data.Annotations, Annotation{
+		Time:       now,
+		Message:    str,
+		Attributes: a,
+	})
+	s.mu.Unlock()
+}
+
+// Annotate adds an annotation with attributes.
+// Attributes can be nil.
+func (s *Span) Annotate(attributes []Attribute, str string) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	s.printStringInternal(attributes, str)
+}
+
+// Annotatef adds an annotation with attributes.
+func (s *Span) Annotatef(attributes []Attribute, format string, a ...interface{}) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	s.lazyPrintfInternal(attributes, format, a...)
+}
+
+// AddMessageSendEvent adds a message send event to the span.
+//
+// messageID is an identifier for the message, which is recommended to be
+// unique in this span and the same between the send event and the receive
+// event (this allows to identify a message between the sender and receiver).
+// For example, this could be a sequence id.
+func (s *Span) AddMessageSendEvent(messageID, uncompressedByteSize, compressedByteSize int64) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	now := time.Now()
+	s.mu.Lock()
+	s.data.MessageEvents = append(s.data.MessageEvents, MessageEvent{
+		Time:                 now,
+		EventType:            MessageEventTypeSent,
+		MessageID:            messageID,
+		UncompressedByteSize: uncompressedByteSize,
+		CompressedByteSize:   compressedByteSize,
+	})
+	s.mu.Unlock()
+}
+
+// AddMessageReceiveEvent adds a message receive event to the span.
+//
+// messageID is an identifier for the message, which is recommended to be
+// unique in this span and the same between the send event and the receive
+// event (this allows to identify a message between the sender and receiver).
+// For example, this could be a sequence id.
+func (s *Span) AddMessageReceiveEvent(messageID, uncompressedByteSize, compressedByteSize int64) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	now := time.Now()
+	s.mu.Lock()
+	s.data.MessageEvents = append(s.data.MessageEvents, MessageEvent{
+		Time:                 now,
+		EventType:            MessageEventTypeRecv,
+		MessageID:            messageID,
+		UncompressedByteSize: uncompressedByteSize,
+		CompressedByteSize:   compressedByteSize,
+	})
+	s.mu.Unlock()
+}
+
+// AddLink adds a link to the span.
+func (s *Span) AddLink(l Link) {
+	if !s.IsRecordingEvents() {
+		return
+	}
+	s.mu.Lock()
+	s.data.Links = append(s.data.Links, l)
+	s.mu.Unlock()
+}
+
+func (s *Span) String() string {
+	if s == nil {
+		return "<nil>"
+	}
+	if s.data == nil {
+		return fmt.Sprintf("span %s", s.spanContext.SpanID)
+	}
+	s.mu.Lock()
+	str := fmt.Sprintf("span %s %q", s.spanContext.SpanID, s.data.Name)
+	s.mu.Unlock()
+	return str
+}
+
+var config atomic.Value // access atomically
+
+func init() {
+	gen := &defaultIDGenerator{}
+	// initialize traceID and spanID generators.
+	var rngSeed int64
+	for _, p := range []interface{}{
+		&rngSeed, &gen.traceIDAdd, &gen.nextSpanID, &gen.spanIDInc,
+	} {
+		binary.Read(crand.Reader, binary.LittleEndian, p)
+	}
+	gen.traceIDRand = rand.New(rand.NewSource(rngSeed))
+	gen.spanIDInc |= 1
+
+	config.Store(&Config{
+		DefaultSampler: ProbabilitySampler(defaultSamplingProbability),
+		IDGenerator:    gen,
+	})
+}
+
+type defaultIDGenerator struct {
+	sync.Mutex
+	traceIDRand *rand.Rand
+	traceIDAdd  [2]uint64
+	nextSpanID  uint64
+	spanIDInc   uint64
+}
+
+// NewSpanID returns a non-zero span ID from a randomly-chosen sequence.
+// mu should be held while this function is called.
+func (gen *defaultIDGenerator) NewSpanID() [8]byte {
+	gen.Lock()
+	id := gen.nextSpanID
+	gen.nextSpanID += gen.spanIDInc
+	if gen.nextSpanID == 0 {
+		gen.nextSpanID += gen.spanIDInc
+	}
+	gen.Unlock()
+	var sid [8]byte
+	binary.LittleEndian.PutUint64(sid[:], id)
+	return sid
+}
+
+// NewTraceID returns a non-zero trace ID from a randomly-chosen sequence.
+// mu should be held while this function is called.
+func (gen *defaultIDGenerator) NewTraceID() [16]byte {
+	var tid [16]byte
+	// Construct the trace ID from two outputs of traceIDRand, with a constant
+	// added to each half for additional entropy.
+	gen.Lock()
+	binary.LittleEndian.PutUint64(tid[0:8], gen.traceIDRand.Uint64()+gen.traceIDAdd[0])
+	binary.LittleEndian.PutUint64(tid[8:16], gen.traceIDRand.Uint64()+gen.traceIDAdd[1])
+	gen.Unlock()
+	return tid
+}

--- a/vendor/go.opencensus.io/trace/trace_go11.go
+++ b/vendor/go.opencensus.io/trace/trace_go11.go
@@ -1,0 +1,32 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build go1.11
+
+package trace
+
+import (
+	"context"
+	t "runtime/trace"
+)
+
+func startExecutionTracerTask(ctx context.Context, name string) (context.Context, func()) {
+	if !t.IsEnabled() {
+		// Avoid additional overhead if
+		// runtime/trace is not enabled.
+		return ctx, func() {}
+	}
+	nctx, task := t.NewTask(ctx, name)
+	return nctx, task.End
+}

--- a/vendor/go.opencensus.io/trace/trace_nongo11.go
+++ b/vendor/go.opencensus.io/trace/trace_nongo11.go
@@ -1,0 +1,25 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !go1.11
+
+package trace
+
+import (
+	"context"
+)
+
+func startExecutionTracerTask(ctx context.Context, name string) (context.Context, func()) {
+	return ctx, func() {}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -928,6 +928,84 @@
 			"revisionTime": "2016-09-30T00:14:02Z"
 		},
 		{
+			"checksumSHA1": "rrTaYIL5Ljr5KLwrNYGKGKBZai8=",
+			"path": "go.opencensus.io/exporter/prometheus",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "LOW01td+oPZdr/Hkff1si4RPz24=",
+			"path": "go.opencensus.io/internal",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "Vcwr4P/uIN4haoJPglU7liURepM=",
+			"path": "go.opencensus.io/internal/tagencoding",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "eI5fdKqeO5GreSenlx5/28XGcIY=",
+			"path": "go.opencensus.io/plugin/ocgrpc",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "BkvseOC+irx2BA7/goHqJUvPOYk=",
+			"path": "go.opencensus.io/plugin/ochttp",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "0OVZlXVUMGzf8ddlnjg2yMZI4ao=",
+			"path": "go.opencensus.io/plugin/ochttp/propagation/b3",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "uMIlbT86FQsxwB8w2u1qMDm2MeA=",
+			"path": "go.opencensus.io/stats",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "R0Glq4iKrvXHiHzbvt+5+Aqo6sY=",
+			"path": "go.opencensus.io/stats/internal",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "1PMqmF+67ReViUshob8eCUT97Cg=",
+			"path": "go.opencensus.io/stats/view",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "ZWdN4cT8j9RFeFkTolXi4hvacwM=",
+			"path": "go.opencensus.io/tag",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "R9E+Gh0GgSgCYWrxDttcmDKsArE=",
+			"path": "go.opencensus.io/trace",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "0P3BycP6CFnFNRCnF4dTlMEJgEI=",
+			"path": "go.opencensus.io/trace/internal",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
+			"checksumSHA1": "FHJParRi8f1GHO7Cx+lk3bMWBq0=",
+			"path": "go.opencensus.io/trace/propagation",
+			"revision": "1b1dcef61d739190527eb01380a75e6f91dea7a9",
+			"revisionTime": "2018-05-30T20:34:25Z"
+		},
+		{
 			"checksumSHA1": "Y+HGqEkYM15ir+J93MEaHdyFy0c=",
 			"path": "golang.org/x/net/context",
 			"revision": "054b33e6527139ad5b1ec2f6232c3b175bd9a30c",


### PR DESCRIPTION
Based on the open questions, a lot of things may still change about this. But this seems like a good first step to get OC metrics in.
It's currently a hybrid, where OC and Prometheus libraries write into the same Prometheus registry.