### PR TITLE
Move retrieval/ to OpenCensus

### DIFF
--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -110,25 +110,25 @@ type PrometheusReader struct {
 }
 
 var (
-	samplesProcessed = stats.Int64("stackdriver.com/prometheus_sidecar/samples_processed", "Number of WAL samples processed", stats.UnitDimensionless)
-	samplesProduced  = stats.Int64("stackdriver.com/prometheus_sidecar/samples_produced", "Number of Stackdriver samples produced", stats.UnitDimensionless)
+	samplesProcessed = stats.Int64("prometheus_sidecar/samples_processed", "Number of WAL samples processed", stats.UnitDimensionless)
+	samplesProduced  = stats.Int64("prometheus_sidecar/samples_produced", "Number of Stackdriver samples produced", stats.UnitDimensionless)
 )
 
 func init() {
 	view.Register(&view.View{
-		Name:        "stackdriver.com/prometheus_sidecar/batches_processed",
+		Name:        "prometheus_sidecar/batches_processed",
 		Description: "Total number of sample batches processed",
 		Measure:     samplesProcessed,
 		Aggregation: view.Count(),
 	})
 	view.Register(&view.View{
-		Name:        "stackdriver.com/prometheus_sidecar/samples_processed",
+		Name:        "prometheus_sidecar/samples_processed",
 		Description: "Number of WAL samples processed",
 		Measure:     samplesProcessed,
 		Aggregation: view.Sum(),
 	})
 	view.Register(&view.View{
-		Name:        "stackdriver.com/prometheus_sidecar/samples_produced",
+		Name:        "prometheus_sidecar/samples_produced",
 		Description: "Number of Stackdriver samples produced",
 		Measure:     samplesProduced,
 		Aggregation: view.Sum(),

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -38,7 +38,7 @@ import (
 )
 
 var (
-	droppedSeries = stats.Int64("stackdriver.com/prometheus_sidecar/dropped_series",
+	droppedSeries = stats.Int64("prometheus_sidecar/dropped_series",
 		"Number of series that were dropped instead of being sent to Stackdriver", stats.UnitDimensionless)
 
 	keyReason, _ = tag.NewKey("reason")
@@ -46,7 +46,7 @@ var (
 
 func init() {
 	if err := view.Register(&view.View{
-		Name:        "stackdriver.com/prometheus_sidecar/dropped_series",
+		Name:        "prometheus_sidecar/dropped_series",
 		Description: "Number of series that were dropped instead of being sent to Stackdriver",
 		Measure:     droppedSeries,
 		TagKeys:     []tag.Key{keyReason},


### PR DESCRIPTION
A few more metrics added/moved to OC.
Remaining Prometheus metrics are now those that Prometheus's library provides by default and the ones in `stackdriver/`. 

Especially those around the runtime are extremely valuable for performance debugging. Until OC gets a viable replacement for those, we'll definitely carry the Prometheus lib around.

As I've learned, the OC `stats` package is not intended for gauges to begin with. Which explains my struggle to migrate the metrics in `stackdriver/`. A dedicated package is intended for those and it's probably best to wait for that to land.  
As far as the intended use cases for `stats/` are concerned, the OC is the best instrumentation library available by a large margin :)