### PR TITLE
Document Prometheus version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The matrix below lists the versions of Prometheus Server and other dependencies 
 
 | sidecar version | prometheus version |
 | --- | --- |
-| 0.1.x | 2.4.0 |
+| 0.1.x | 2.4.3 |
 
 ## Source Code Headers
 


### PR DESCRIPTION
Fabian, can you confirm that 2.4.x works? I'll follow up with a release script and mark the first release as 0.1.