### PR TITLE
Updated release compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ can be used as a reference for setup:
 
 The matrix below lists the versions of Prometheus Server and other dependencies that have been qualified to work with releases of `stackdriver-prometheus-sidecar`.
 
-| sidecar version | **Prometheus 2.4.3** | **Prometheus 2.5.x** |
-|------------|------------------|-------------------|
-| **0.2.x**  |        ✓         |         -         |
-| **master** |        ✓         |         ✓         |
+| sidecar version | **Prometheus 2.4.3** | **Prometheus 2.5.x** | **Prometheus 2.5.x** |
+|------------|------------------|-------------------|-------------------|
+| **0.2.x**  |        ✓         |         -         |         -         |
+| **0.3.x**  |        ✓         |         -         |         ✓         |
 
 ## Source Code Headers
 

--- a/release.sh
+++ b/release.sh
@@ -24,5 +24,4 @@ echo "${version}" > VERSION
 git checkout -b "release-${version}"
 
 # 3. Run `DOCKER_IMAGE_NAME={public_docker_image} make push`.
-# TODO(jkohen): This is the public repo. It should replace the line below when we go public. 
 DOCKER_IMAGE_NAME="gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar" make push


### PR DESCRIPTION
Added release 0.3.0 with compatibility for the next Prometheus release, which is expected to be 2.6.0 (but could be 2.5.1). We can't support Prometheus Server 2.5.0 due to a bug in that release.