### PR TITLE
Use bash for deploy.sh

### DIFF
--- a/kube/full/deploy.sh
+++ b/kube/full/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 set -u


### PR DESCRIPTION
`sh` doesn't have access to pushd, so we should be using `bash`, otherwise it fails.