### PR TITLE
Make the API URLs relative

### DIFF
--- a/cmd/stackdriver-prometheus-sidecar/main.go
+++ b/cmd/stackdriver-prometheus-sidecar/main.go
@@ -151,12 +151,6 @@ type genericConfig struct {
 	namespace string
 }
 
-type gceMetadata struct {
-	projectID string
-	location  string
-	cluster   string
-}
-
 type fileConfig struct {
 	MetricRenames []struct {
 		From string `json:"from"`

--- a/metadata/cache.go
+++ b/metadata/cache.go
@@ -44,7 +44,7 @@ type Cache struct {
 
 // DefaultEndpointPath is the default HTTP path on which Prometheus serves
 // the target metadata endpoint.
-const DefaultEndpointPath = "/api/v1/targets/metadata"
+const DefaultEndpointPath = "api/v1/targets/metadata"
 
 // The old metric type value for textparse.MetricTypeUnknown that is used in
 // Prometheus 2.4 and earlier.

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -27,7 +27,6 @@ import (
 	"github.com/prometheus/tsdb"
 	tsdbLabels "github.com/prometheus/tsdb/labels"
 	distribution_pb "google.golang.org/genproto/googleapis/api/distribution"
-	metric_pb "google.golang.org/genproto/googleapis/api/metric"
 	monitoring_pb "google.golang.org/genproto/googleapis/monitoring/v3"
 )
 
@@ -150,20 +149,6 @@ func getMetricType(prefix string, promName string) string {
 		return metricsPrefix + "/" + promName
 	}
 	return prefix + "/" + promName
-}
-
-func getMetricKind(t textparse.MetricType) metric_pb.MetricDescriptor_MetricKind {
-	if t == textparse.MetricTypeCounter || t == textparse.MetricTypeHistogram {
-		return metric_pb.MetricDescriptor_CUMULATIVE
-	}
-	return metric_pb.MetricDescriptor_GAUGE
-}
-
-func getValueType(t textparse.MetricType) metric_pb.MetricDescriptor_ValueType {
-	if t == textparse.MetricTypeHistogram {
-		return metric_pb.MetricDescriptor_DISTRIBUTION
-	}
-	return metric_pb.MetricDescriptor_DOUBLE
 }
 
 // getTimestamp converts a millisecond timestamp into a protobuf timestamp.

--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -37,7 +37,6 @@ import (
 )
 
 const (
-	metricsPrefix             = "external.googleapis.com/prometheus"
 	MaxTimeseriesesPerRequest = 200
 	MonitoringWriteScope      = "https://www.googleapis.com/auth/monitoring.write"
 )

--- a/stackdriver/client_test.go
+++ b/stackdriver/client_test.go
@@ -41,7 +41,6 @@ func newLocalListener() net.Listener {
 
 func TestStoreErrorHandling(t *testing.T) {
 	tests := []struct {
-		code        int
 		status      *status.Status
 		recoverable bool
 	}{

--- a/stackdriver/queue_manager.go
+++ b/stackdriver/queue_manager.go
@@ -408,7 +408,6 @@ func newShard(cfg config.QueueConfig) shard {
 
 type shardCollection struct {
 	qm     *QueueManager
-	client StorageClient
 	shards []shard
 	done   chan struct{}
 	wg     sync.WaitGroup
@@ -426,10 +425,6 @@ func (t *QueueManager) newShardCollection(numShards int) *shardCollection {
 	}
 	s.wg.Add(numShards)
 	return s
-}
-
-func (s *shardCollection) len() int {
-	return len(s.shards)
 }
 
 func (s *shardCollection) start() {

--- a/targets/cache.go
+++ b/targets/cache.go
@@ -27,7 +27,7 @@ import (
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-const DefaultAPIEndpoint = "/api/v1/targets"
+const DefaultAPIEndpoint = "api/v1/targets"
 
 func cacheKey(job, instance string) string {
 	return job + "\xff" + instance


### PR DESCRIPTION
This is so that any paths in the API prefix URL are preserved. E.g. `url.Parse("http://127.0.0.1:9090/foo").Parse("bar")` gives `"http://127.0.0.1:9090/foo/bar"`

Closes #71 