### PR TITLE
Update Compatibility Matrix with sidecar 0.4.x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ static_metadata:
 
 The matrix below lists the versions of Prometheus Server and other dependencies that have been qualified to work with releases of `stackdriver-prometheus-sidecar`.
 
-| sidecar version | **Prometheus 2.4.3** | **Prometheus 2.5.x** | **Prometheus 2.6.x** |
-|------------|------------------|-------------------|-------------------|
-| **0.2.x**  |        ✓         |         -         |         -         |
-| **0.3.x**  |        ✓         |         -         |         ✓         |
+| sidecar version | **Prometheus 2.4.3**| **Prometheus 2.5.x**| **Prometheus 2.6.x**|
+|-----------------|---------------------|---------------------|---------------------|
+| **0.2.x**       |          ✓          |          -          |          -          |
+| **0.3.x**       |          ✓          |          -          |          ✓          |
+| **0.4.x**       |          -          |          -          |          ✓          |
 
 ## Alternatives
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ stackdriver-prometheus-sidecar \
   --stackdriver.project-id=${GCP_PROJECT} \
   --prometheus.wal-directory=${WAL_DIR} \
   --prometheus.api-address=${API_ADDRESS} \
-  --stackdriver.kubernetes.location=${REGION} \ 
+  --stackdriver.kubernetes.location=${REGION} \
   --stackdriver.kubernetes.cluster-name=${CLUSTER}
 ```
 
@@ -79,9 +79,13 @@ The matrix below lists the versions of Prometheus Server and other dependencies 
 
 | sidecar version | **Prometheus 2.4.3**| **Prometheus 2.5.x**| **Prometheus 2.6.x**|
 |-----------------|---------------------|---------------------|---------------------|
-| **0.2.x**       |          ✓          |          -          |          -          |
-| **0.3.x**       |          ✓          |          -          |          ✓          |
-| **0.4.x**       |          -          |          -          |          ✓          |
+| **0.2.x**       |          ✓          |          ✗          |          ✗          |
+| **0.3.x**       |          ✓          |          ✗          |          ✓          |
+| **0.4.x**       |          ?          |          ✗          |          ✓          |
+
+- ✓: Verified as compatible.
+- ✗: Verified as incompatible.
+- ?: Not verified yet.
 
 ## Alternatives
 


### PR DESCRIPTION
Ran [e2e test](https://github.com/Stackdriver/stackdriver-prometheus-sidecar/blob/v0.4.0/RELEASE-PROCESS.md#release-process) when released 0.4.0, which specified [Prometheus 2.6.0](https://github.com/Stackdriver/stackdriver-prometheus-sidecar/blob/e246041acf99c8487e1ac73552fb8625339c64a1/kube/full/prometheus.yaml#L101) and succeeded. Therefore, add this section into the compatibility graph.