### PR TITLE
Advise users about the possible billing charges before deploying the sidecar

### DIFF
--- a/kube/full/deploy.sh
+++ b/kube/full/deploy.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [ "$I_ACCEPT_THE_BILLING_CHARGES" != "true" ]; then
+    printf 'The default configuration of Stackdriver Prometheus Sidecar sends metrics at a rate\n'
+    printf 'billed between $25 and $50/node/day on a cluster; approximately $1500/node/month.\n\n'
+
+    printf "Please set the environment variable I_ACCEPT_THE_BILLING_CHARGES=true to continue\n"
+    exit
+fi
+
 set -e
 set -u
 

--- a/kube/patch-operated.sh
+++ b/kube/patch-operated.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+if [ "$I_ACCEPT_THE_BILLING_CHARGES" != "true" ]; then
+    printf 'The default configuration of Stackdriver Prometheus Sidecar sends metrics at a rate\n'
+    printf 'billed between $25 and $50/node/day on a cluster; approximately $1500/node/month.\n\n'
+
+    printf "Please set the environment variable I_ACCEPT_THE_BILLING_CHARGES=true to continue\n"
+    exit
+fi
+
 set -e
 set -u
 

--- a/kube/patch.sh
+++ b/kube/patch.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+if [ "$I_ACCEPT_THE_BILLING_CHARGES" != "true" ]; then
+    printf 'The default configuration of Stackdriver Prometheus Sidecar sends metrics at a rate\n'
+    printf 'billed between $25 and $50/node/day on a cluster; approximately $1500/node/month.\n\n'
+
+    printf "Please set the environment variable I_ACCEPT_THE_BILLING_CHARGES=true to continue\n"
+    exit
+fi
+
 set -e
 set -u
 


### PR DESCRIPTION
This is from personal experience, observing a $3000 bill in about ten days from running this sidecar on a few three-node GKE clusters. (Imagine if we had deployed this to a production cluster of 1,000 nodes!)

If any Stackdriver personnel know how to escalate this to billing support and add a warning to the [GCP documentation](https://cloud.google.com/monitoring/kubernetes-engine/prometheus), that would be advisable.