### PR TITLE
Apply OR logic when multiple --filter parameters are specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ stackdriver-prometheus-sidecar --help
 
 #### Filters
 
-The `--filter` flag allows to provide filters which all series have to pass before being sent to Stackdriver. The flag may be repeated to provide several filters. Filters use the same syntax as the well-known PromQL label matchers, e.g.:
+The `--filter` flag allows to provide filters which all series have to pass before being sent to Stackdriver. The flag may be repeated to provide several filters, time series must match one of the filters .  Filters use the same syntax as the well-known PromQL label matchers, e.g.:
 
 ```
 stackdriver-prometheus-sidecar --filter='job="k8s"' --filter='__name__!~"cadvisor_.+"' ...
 ```
 
-This drops all series which do not have a `job` label `k8s` and all metrics that have a name starting with `cadvisor_`.
+This sends to Stackdriver only time series which do have a `job` label `k8s` or metrics that have a name not starting with `cadvisor_`.
 
 #### File
 

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -303,8 +303,16 @@ func (c *seriesCache) getResetAdjusted(ref uint64, t int64, v float64) (int64, f
 // set the label set for the given reference.
 // maxSegment indicates the the highest segment at which the series was possibly defined.
 func (c *seriesCache) set(ctx context.Context, ref uint64, lset labels.Labels, maxSegment int) error {
-	for _, f := range c.filters {
-		if v := lset.Get(f.Name); !f.Matches(v) {
+	if c.filters != nil {
+		matched := false
+		// label set must match one of the filters
+		for _, f := range c.filters {
+			if v := lset.Get(f.Name); f.Matches(v) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
 			return nil
 		}
 	}

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -260,18 +260,28 @@ func TestSeriesCache_Filter(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, ok, err := c.get(ctx, 1); !ok || err != nil {
-		t.Fatalf("metric not found: %s", err)
+		t.Fatalf("error retrieving metric: %s", err)
+	} else if !ok {
+		t.Fatalf("metric was filtered, though it should not")
 	}
-	// Test filtered metric.
+	// Test metric that passed one of the filters.
 	err = c.set(ctx, 2, labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a1", "b", "b2"), 1)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if _, ok, err := c.get(ctx, 2); err != nil {
 		t.Fatalf("error retrieving metric: %s", err)
+	} else if !ok {
+		t.Fatalf("metric was filtered, though it should not")
+	}
+	// Test metric that does not pass any of the filters
+	err = c.set(ctx, 3, labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a2", "b", "b2"), 1)
+	if _, ok, err := c.get(ctx, 3); err != nil {
+		t.Fatalf("error retrieving metric: %s", err)
 	} else if ok {
 		t.Fatalf("metric was not filtered")
 	}
+
 }
 
 func TestSeriesCache_RenameMetric(t *testing.T) {


### PR DESCRIPTION
A pretty common scenario of the sidecar is to filter metrics using OR logic. 
Consider the following scenario: "send to Stackdriver time series for a metric  "foo" where label  "label1" has values A, B or C OR send time series  for a metric "bar" where label "label2" has values D, E or F.   Drop everything else
It's impossible (or very tough) to express such scenario as a single PromQL label matcher expression. And specifying multiple filters in the current implementation does not help, as multiple filters had AND logic up until now.
This pull request changes logic of combining multiple filters with OR instead of AND.

