### PR TITLE
Fix comment for updateSampleInterval.

### DIFF
--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -65,7 +65,7 @@ type seriesGetter interface {
 	getResetAdjusted(ref uint64, t int64, v float64) (int64, float64, bool)
 
 	// Attempt to set the new most recent time range for the series with given hash.
-	// Returns true if it failed, in which case the sample must be discarded.
+	// Returns false if it failed, in which case the sample must be discarded.
 	updateSampleInterval(hash uint64, start, end int64) bool
 }
 
@@ -251,7 +251,7 @@ func (c *seriesCache) get(ctx context.Context, ref uint64) (*seriesCacheEntry, b
 }
 
 // updateSampleInterval attempts to set the new most recent time range for the series with given hash.
-// Returns true if it failed, in which case the sample must be discarded.
+// Returns false if it failed, in which case the sample must be discarded.
 func (c *seriesCache) updateSampleInterval(hash uint64, start, end int64) bool {
 	iv, ok := c.intervals[hash]
 	if !ok || iv.accepts(start, end) {


### PR DESCRIPTION
The function actually returns 'false' if it failed, in which case we do
discard the sample in sampleBuilder.next().