### PR TITLE
Allow specifying multiple filtersets.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore checkpoint file.
 stackdriver_sidecar.json
+stackdriver-prometheus-sidecar

--- a/README.md
+++ b/README.md
@@ -48,15 +48,17 @@ stackdriver-prometheus-sidecar --help
 
 #### Filters
 
-The `--filter` flag allows to provide filters which all series have to pass before being sent to Stackdriver. The flag may be repeated to provide several filters. Filters use the same syntax as the well-known PromQL label matchers, e.g.:
+The `--include` flag allows to provide filters which all series have to pass before being sent to Stackdriver. Filters use the same syntax as [Prometheus instant vector selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors), e.g.:
 
 ```
-stackdriver-prometheus-sidecar --filter=job="k8s" --filter=__name__!~"cadvisor_.+" ...
+stackdriver-prometheus-sidecar --include='{__name__!~"cadvisor_.+",job="k8s"}' ...
 ```
 
 This drops all series which do not have a `job` label `k8s` and all metrics that have a name starting with `cadvisor_`.
 
-Note: On the command-line shell you may need to escape filters as `--filter='job="k8s"'`.
+For equality filter on metric name you can use the simpler notation, e.g. `--include='metric_name{label="foo"}'`.
+
+The flag may be repeated to provide several sets of filters, in which case the metric will be forwarded if it matches at least one of them.
 
 #### File
 

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -80,7 +80,7 @@ func NewPrometheusReader(
 	logger log.Logger,
 	walDirectory string,
 	tailer *tail.Tailer,
-	filters []*labels.Matcher,
+	filtersets [][]*labels.Matcher,
 	metricRenames map[string]string,
 	targetGetter TargetGetter,
 	metadataGetter MetadataGetter,
@@ -95,7 +95,7 @@ func NewPrometheusReader(
 		appender:             appender,
 		logger:               logger,
 		tailer:               tailer,
-		filters:              filters,
+		filtersets:           filtersets,
 		walDirectory:         walDirectory,
 		targetGetter:         targetGetter,
 		metadataGetter:       metadataGetter,
@@ -110,7 +110,7 @@ type PrometheusReader struct {
 	logger               log.Logger
 	walDirectory         string
 	tailer               *tail.Tailer
-	filters              []*labels.Matcher
+	filtersets           [][]*labels.Matcher
 	metricRenames        map[string]string
 	targetGetter         TargetGetter
 	metadataGetter       MetadataGetter
@@ -152,7 +152,7 @@ func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 	seriesCache := newSeriesCache(
 		r.logger,
 		r.walDirectory,
-		r.filters,
+		r.filtersets,
 		r.metricRenames,
 		r.targetGetter,
 		r.metadataGetter,

--- a/vendor/github.com/opentracing/opentracing-go/CHANGELOG.md
+++ b/vendor/github.com/opentracing/opentracing-go/CHANGELOG.md
@@ -1,0 +1,46 @@
+Changes by Version
+==================
+
+1.1.0 (2019-03-23)
+-------------------
+
+Notable changes:
+- The library is now released under Apache 2.0 license
+- Use Set() instead of Add() in HTTPHeadersCarrier is functionally a breaking change (fixes issue [#159](https://github.com/opentracing/opentracing-go/issues/159))
+- 'golang.org/x/net/context' is replaced with 'context' from the standard library
+
+List of all changes:
+
+- Export StartSpanFromContextWithTracer (#214) <Aaron Delaney>
+- Add IsGlobalTracerRegistered() to indicate if a tracer has been registered (#201) <Mike Goldsmith>
+- Use Set() instead of Add() in HTTPHeadersCarrier (#191) <jeremyxu2010>
+- Update license to Apache 2.0 (#181) <Andrea Kao>
+- Replace 'golang.org/x/net/context' with 'context' (#176) <Tony Ghita>
+- Port of Python opentracing/harness/api_check.py to Go (#146) <chris erway>
+- Fix race condition in MockSpan.Context() (#170) <Brad>
+- Add PeerHostIPv4.SetString() (#155)  <NeoCN>
+- Add a Noop log field type to log to allow for optional fields (#150)  <Matt Ho>
+
+
+1.0.2 (2017-04-26)
+-------------------
+
+- Add more semantic tags (#139) <Rustam Zagirov>
+
+
+1.0.1 (2017-02-06)
+-------------------
+
+- Correct spelling in comments <Ben Sigelman>
+- Address race in nextMockID() (#123) <bill fumerola>
+- log: avoid panic marshaling nil error (#131) <Anthony Voutas>
+- Deprecate InitGlobalTracer in favor of SetGlobalTracer (#128) <Yuri Shkuro>
+- Drop Go 1.5 that fails in Travis (#129) <Yuri Shkuro>
+- Add convenience methods Key() and Value() to log.Field <Ben Sigelman>
+- Add convenience methods to log.Field (2 years, 6 months ago) <Radu Berinde>
+
+1.0.0 (2016-09-26)
+-------------------
+
+- This release implements OpenTracing Specification 1.0 (https://opentracing.io/spec)
+

--- a/vendor/github.com/opentracing/opentracing-go/LICENSE
+++ b/vendor/github.com/opentracing/opentracing-go/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2016 The OpenTracing Authors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opentracing/opentracing-go/Makefile
+++ b/vendor/github.com/opentracing/opentracing-go/Makefile
@@ -1,0 +1,20 @@
+.DEFAULT_GOAL := test-and-lint
+
+.PHONY: test-and-lint
+test-and-lint: test lint
+
+.PHONY: test
+test:
+	go test -v -cover -race ./...
+
+.PHONY: cover
+cover:
+	go test -v -coverprofile=coverage.txt -covermode=atomic -race ./...
+
+.PHONY: lint
+lint:
+	go fmt ./...
+	golint ./...
+	@# Run again with magic to exit non-zero if golint outputs anything.
+	@! (golint ./... | read dummy)
+	go vet ./...

--- a/vendor/github.com/opentracing/opentracing-go/README.md
+++ b/vendor/github.com/opentracing/opentracing-go/README.md
@@ -1,0 +1,171 @@
+[![Gitter chat](http://img.shields.io/badge/gitter-join%20chat%20%E2%86%92-brightgreen.svg)](https://gitter.im/opentracing/public) [![Build Status](https://travis-ci.org/opentracing/opentracing-go.svg?branch=master)](https://travis-ci.org/opentracing/opentracing-go) [![GoDoc](https://godoc.org/github.com/opentracing/opentracing-go?status.svg)](http://godoc.org/github.com/opentracing/opentracing-go)
+[![Sourcegraph Badge](https://sourcegraph.com/github.com/opentracing/opentracing-go/-/badge.svg)](https://sourcegraph.com/github.com/opentracing/opentracing-go?badge)
+
+# OpenTracing API for Go
+
+This package is a Go platform API for OpenTracing.
+
+## Required Reading
+
+In order to understand the Go platform API, one must first be familiar with the
+[OpenTracing project](https://opentracing.io) and
+[terminology](https://opentracing.io/specification/) more specifically.
+
+## API overview for those adding instrumentation
+
+Everyday consumers of this `opentracing` package really only need to worry
+about a couple of key abstractions: the `StartSpan` function, the `Span`
+interface, and binding a `Tracer` at `main()`-time. Here are code snippets
+demonstrating some important use cases.
+
+#### Singleton initialization
+
+The simplest starting point is `./default_tracer.go`. As early as possible, call
+
+```go
+    import "github.com/opentracing/opentracing-go"
+    import ".../some_tracing_impl"
+
+    func main() {
+        opentracing.SetGlobalTracer(
+            // tracing impl specific:
+            some_tracing_impl.New(...),
+        )
+        ...
+    }
+```
+
+#### Non-Singleton initialization
+
+If you prefer direct control to singletons, manage ownership of the
+`opentracing.Tracer` implementation explicitly.
+
+#### Creating a Span given an existing Go `context.Context`
+
+If you use `context.Context` in your application, OpenTracing's Go library will
+happily rely on it for `Span` propagation. To start a new (blocking child)
+`Span`, you can use `StartSpanFromContext`.
+
+```go
+    func xyz(ctx context.Context, ...) {
+        ...
+        span, ctx := opentracing.StartSpanFromContext(ctx, "operation_name")
+        defer span.Finish()
+        span.LogFields(
+            log.String("event", "soft error"),
+            log.String("type", "cache timeout"),
+            log.Int("waited.millis", 1500))
+        ...
+    }
+```
+
+#### Starting an empty trace by creating a "root span"
+
+It's always possible to create a "root" `Span` with no parent or other causal
+reference.
+
+```go
+    func xyz() {
+        ...
+        sp := opentracing.StartSpan("operation_name")
+        defer sp.Finish()
+        ...
+    }
+```
+
+#### Creating a (child) Span given an existing (parent) Span
+
+```go
+    func xyz(parentSpan opentracing.Span, ...) {
+        ...
+        sp := opentracing.StartSpan(
+            "operation_name",
+            opentracing.ChildOf(parentSpan.Context()))
+        defer sp.Finish()
+        ...
+    }
+```
+
+#### Serializing to the wire
+
+```go
+    func makeSomeRequest(ctx context.Context) ... {
+        if span := opentracing.SpanFromContext(ctx); span != nil {
+            httpClient := &http.Client{}
+            httpReq, _ := http.NewRequest("GET", "http://myservice/", nil)
+
+            // Transmit the span's TraceContext as HTTP headers on our
+            // outbound request.
+            opentracing.GlobalTracer().Inject(
+                span.Context(),
+                opentracing.HTTPHeaders,
+                opentracing.HTTPHeadersCarrier(httpReq.Header))
+
+            resp, err := httpClient.Do(httpReq)
+            ...
+        }
+        ...
+    }
+```
+
+#### Deserializing from the wire
+
+```go
+    http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+        var serverSpan opentracing.Span
+        appSpecificOperationName := ...
+        wireContext, err := opentracing.GlobalTracer().Extract(
+            opentracing.HTTPHeaders,
+            opentracing.HTTPHeadersCarrier(req.Header))
+        if err != nil {
+            // Optionally record something about err here
+        }
+
+        // Create the span referring to the RPC client if available.
+        // If wireContext == nil, a root span will be created.
+        serverSpan = opentracing.StartSpan(
+            appSpecificOperationName,
+            ext.RPCServerOption(wireContext))
+
+        defer serverSpan.Finish()
+
+        ctx := opentracing.ContextWithSpan(context.Background(), serverSpan)
+        ...
+    }
+```
+
+#### Conditionally capture a field using `log.Noop`
+
+In some situations, you may want to dynamically decide whether or not
+to log a field.  For example, you may want to capture additional data,
+such as a customer ID, in non-production environments:
+
+```go
+    func Customer(order *Order) log.Field {
+        if os.Getenv("ENVIRONMENT") == "dev" {
+            return log.String("customer", order.Customer.ID)
+        }
+        return log.Noop()
+    }
+```
+
+#### Goroutine-safety
+
+The entire public API is goroutine-safe and does not require external
+synchronization.
+
+## API pointers for those implementing a tracing system
+
+Tracing system implementors may be able to reuse or copy-paste-modify the `basictracer` package, found [here](https://github.com/opentracing/basictracer-go). In particular, see `basictracer.New(...)`.
+
+## API compatibility
+
+For the time being, "mild" backwards-incompatible changes may be made without changing the major version number. As OpenTracing and `opentracing-go` mature, backwards compatibility will become more of a priority.
+
+## Tracer test suite
+
+A test suite is available in the [harness](https://godoc.org/github.com/opentracing/opentracing-go/harness) package that can assist Tracer implementors to assert that their Tracer is working correctly.
+
+## Licensing
+
+[Apache 2.0 License](./LICENSE).

--- a/vendor/github.com/opentracing/opentracing-go/globaltracer.go
+++ b/vendor/github.com/opentracing/opentracing-go/globaltracer.go
@@ -1,0 +1,42 @@
+package opentracing
+
+type registeredTracer struct {
+	tracer       Tracer
+	isRegistered bool
+}
+
+var (
+	globalTracer = registeredTracer{NoopTracer{}, false}
+)
+
+// SetGlobalTracer sets the [singleton] opentracing.Tracer returned by
+// GlobalTracer(). Those who use GlobalTracer (rather than directly manage an
+// opentracing.Tracer instance) should call SetGlobalTracer as early as
+// possible in main(), prior to calling the `StartSpan` global func below.
+// Prior to calling `SetGlobalTracer`, any Spans started via the `StartSpan`
+// (etc) globals are noops.
+func SetGlobalTracer(tracer Tracer) {
+	globalTracer = registeredTracer{tracer, true}
+}
+
+// GlobalTracer returns the global singleton `Tracer` implementation.
+// Before `SetGlobalTracer()` is called, the `GlobalTracer()` is a noop
+// implementation that drops all data handed to it.
+func GlobalTracer() Tracer {
+	return globalTracer.tracer
+}
+
+// StartSpan defers to `Tracer.StartSpan`. See `GlobalTracer()`.
+func StartSpan(operationName string, opts ...StartSpanOption) Span {
+	return globalTracer.tracer.StartSpan(operationName, opts...)
+}
+
+// InitGlobalTracer is deprecated. Please use SetGlobalTracer.
+func InitGlobalTracer(tracer Tracer) {
+	SetGlobalTracer(tracer)
+}
+
+// IsGlobalTracerRegistered returns a `bool` to indicate if a tracer has been globally registered
+func IsGlobalTracerRegistered() bool {
+	return globalTracer.isRegistered
+}

--- a/vendor/github.com/opentracing/opentracing-go/gocontext.go
+++ b/vendor/github.com/opentracing/opentracing-go/gocontext.go
@@ -1,0 +1,60 @@
+package opentracing
+
+import "context"
+
+type contextKey struct{}
+
+var activeSpanKey = contextKey{}
+
+// ContextWithSpan returns a new `context.Context` that holds a reference to
+// `span`'s SpanContext.
+func ContextWithSpan(ctx context.Context, span Span) context.Context {
+	return context.WithValue(ctx, activeSpanKey, span)
+}
+
+// SpanFromContext returns the `Span` previously associated with `ctx`, or
+// `nil` if no such `Span` could be found.
+//
+// NOTE: context.Context != SpanContext: the former is Go's intra-process
+// context propagation mechanism, and the latter houses OpenTracing's per-Span
+// identity and baggage information.
+func SpanFromContext(ctx context.Context) Span {
+	val := ctx.Value(activeSpanKey)
+	if sp, ok := val.(Span); ok {
+		return sp
+	}
+	return nil
+}
+
+// StartSpanFromContext starts and returns a Span with `operationName`, using
+// any Span found within `ctx` as a ChildOfRef. If no such parent could be
+// found, StartSpanFromContext creates a root (parentless) Span.
+//
+// The second return value is a context.Context object built around the
+// returned Span.
+//
+// Example usage:
+//
+//    SomeFunction(ctx context.Context, ...) {
+//        sp, ctx := opentracing.StartSpanFromContext(ctx, "SomeFunction")
+//        defer sp.Finish()
+//        ...
+//    }
+func StartSpanFromContext(ctx context.Context, operationName string, opts ...StartSpanOption) (Span, context.Context) {
+	return StartSpanFromContextWithTracer(ctx, GlobalTracer(), operationName, opts...)
+}
+
+// StartSpanFromContextWithTracer starts and returns a span with `operationName`
+// using  a span found within the context as a ChildOfRef. If that doesn't exist
+// it creates a root span. It also returns a context.Context object built
+// around the returned span.
+//
+// It's behavior is identical to StartSpanFromContext except that it takes an explicit
+// tracer as opposed to using the global tracer.
+func StartSpanFromContextWithTracer(ctx context.Context, tracer Tracer, operationName string, opts ...StartSpanOption) (Span, context.Context) {
+	if parentSpan := SpanFromContext(ctx); parentSpan != nil {
+		opts = append(opts, ChildOf(parentSpan.Context()))
+	}
+	span := tracer.StartSpan(operationName, opts...)
+	return span, ContextWithSpan(ctx, span)
+}

--- a/vendor/github.com/opentracing/opentracing-go/log/field.go
+++ b/vendor/github.com/opentracing/opentracing-go/log/field.go
@@ -1,0 +1,269 @@
+package log
+
+import (
+	"fmt"
+	"math"
+)
+
+type fieldType int
+
+const (
+	stringType fieldType = iota
+	boolType
+	intType
+	int32Type
+	uint32Type
+	int64Type
+	uint64Type
+	float32Type
+	float64Type
+	errorType
+	objectType
+	lazyLoggerType
+	noopType
+)
+
+// Field instances are constructed via LogBool, LogString, and so on.
+// Tracing implementations may then handle them via the Field.Marshal
+// method.
+//
+// "heavily influenced by" (i.e., partially stolen from)
+// https://github.com/uber-go/zap
+type Field struct {
+	key          string
+	fieldType    fieldType
+	numericVal   int64
+	stringVal    string
+	interfaceVal interface{}
+}
+
+// String adds a string-valued key:value pair to a Span.LogFields() record
+func String(key, val string) Field {
+	return Field{
+		key:       key,
+		fieldType: stringType,
+		stringVal: val,
+	}
+}
+
+// Bool adds a bool-valued key:value pair to a Span.LogFields() record
+func Bool(key string, val bool) Field {
+	var numericVal int64
+	if val {
+		numericVal = 1
+	}
+	return Field{
+		key:        key,
+		fieldType:  boolType,
+		numericVal: numericVal,
+	}
+}
+
+// Int adds an int-valued key:value pair to a Span.LogFields() record
+func Int(key string, val int) Field {
+	return Field{
+		key:        key,
+		fieldType:  intType,
+		numericVal: int64(val),
+	}
+}
+
+// Int32 adds an int32-valued key:value pair to a Span.LogFields() record
+func Int32(key string, val int32) Field {
+	return Field{
+		key:        key,
+		fieldType:  int32Type,
+		numericVal: int64(val),
+	}
+}
+
+// Int64 adds an int64-valued key:value pair to a Span.LogFields() record
+func Int64(key string, val int64) Field {
+	return Field{
+		key:        key,
+		fieldType:  int64Type,
+		numericVal: val,
+	}
+}
+
+// Uint32 adds a uint32-valued key:value pair to a Span.LogFields() record
+func Uint32(key string, val uint32) Field {
+	return Field{
+		key:        key,
+		fieldType:  uint32Type,
+		numericVal: int64(val),
+	}
+}
+
+// Uint64 adds a uint64-valued key:value pair to a Span.LogFields() record
+func Uint64(key string, val uint64) Field {
+	return Field{
+		key:        key,
+		fieldType:  uint64Type,
+		numericVal: int64(val),
+	}
+}
+
+// Float32 adds a float32-valued key:value pair to a Span.LogFields() record
+func Float32(key string, val float32) Field {
+	return Field{
+		key:        key,
+		fieldType:  float32Type,
+		numericVal: int64(math.Float32bits(val)),
+	}
+}
+
+// Float64 adds a float64-valued key:value pair to a Span.LogFields() record
+func Float64(key string, val float64) Field {
+	return Field{
+		key:        key,
+		fieldType:  float64Type,
+		numericVal: int64(math.Float64bits(val)),
+	}
+}
+
+// Error adds an error with the key "error" to a Span.LogFields() record
+func Error(err error) Field {
+	return Field{
+		key:          "error",
+		fieldType:    errorType,
+		interfaceVal: err,
+	}
+}
+
+// Object adds an object-valued key:value pair to a Span.LogFields() record
+func Object(key string, obj interface{}) Field {
+	return Field{
+		key:          key,
+		fieldType:    objectType,
+		interfaceVal: obj,
+	}
+}
+
+// LazyLogger allows for user-defined, late-bound logging of arbitrary data
+type LazyLogger func(fv Encoder)
+
+// Lazy adds a LazyLogger to a Span.LogFields() record; the tracing
+// implementation will call the LazyLogger function at an indefinite time in
+// the future (after Lazy() returns).
+func Lazy(ll LazyLogger) Field {
+	return Field{
+		fieldType:    lazyLoggerType,
+		interfaceVal: ll,
+	}
+}
+
+// Noop creates a no-op log field that should be ignored by the tracer.
+// It can be used to capture optional fields, for example those that should
+// only be logged in non-production environment:
+//
+//     func customerField(order *Order) log.Field {
+//          if os.Getenv("ENVIRONMENT") == "dev" {
+//              return log.String("customer", order.Customer.ID)
+//          }
+//          return log.Noop()
+//     }
+//
+//     span.LogFields(log.String("event", "purchase"), customerField(order))
+//
+func Noop() Field {
+	return Field{
+		fieldType: noopType,
+	}
+}
+
+// Encoder allows access to the contents of a Field (via a call to
+// Field.Marshal).
+//
+// Tracer implementations typically provide an implementation of Encoder;
+// OpenTracing callers typically do not need to concern themselves with it.
+type Encoder interface {
+	EmitString(key, value string)
+	EmitBool(key string, value bool)
+	EmitInt(key string, value int)
+	EmitInt32(key string, value int32)
+	EmitInt64(key string, value int64)
+	EmitUint32(key string, value uint32)
+	EmitUint64(key string, value uint64)
+	EmitFloat32(key string, value float32)
+	EmitFloat64(key string, value float64)
+	EmitObject(key string, value interface{})
+	EmitLazyLogger(value LazyLogger)
+}
+
+// Marshal passes a Field instance through to the appropriate
+// field-type-specific method of an Encoder.
+func (lf Field) Marshal(visitor Encoder) {
+	switch lf.fieldType {
+	case stringType:
+		visitor.EmitString(lf.key, lf.stringVal)
+	case boolType:
+		visitor.EmitBool(lf.key, lf.numericVal != 0)
+	case intType:
+		visitor.EmitInt(lf.key, int(lf.numericVal))
+	case int32Type:
+		visitor.EmitInt32(lf.key, int32(lf.numericVal))
+	case int64Type:
+		visitor.EmitInt64(lf.key, int64(lf.numericVal))
+	case uint32Type:
+		visitor.EmitUint32(lf.key, uint32(lf.numericVal))
+	case uint64Type:
+		visitor.EmitUint64(lf.key, uint64(lf.numericVal))
+	case float32Type:
+		visitor.EmitFloat32(lf.key, math.Float32frombits(uint32(lf.numericVal)))
+	case float64Type:
+		visitor.EmitFloat64(lf.key, math.Float64frombits(uint64(lf.numericVal)))
+	case errorType:
+		if err, ok := lf.interfaceVal.(error); ok {
+			visitor.EmitString(lf.key, err.Error())
+		} else {
+			visitor.EmitString(lf.key, "<nil>")
+		}
+	case objectType:
+		visitor.EmitObject(lf.key, lf.interfaceVal)
+	case lazyLoggerType:
+		visitor.EmitLazyLogger(lf.interfaceVal.(LazyLogger))
+	case noopType:
+		// intentionally left blank
+	}
+}
+
+// Key returns the field's key.
+func (lf Field) Key() string {
+	return lf.key
+}
+
+// Value returns the field's value as interface{}.
+func (lf Field) Value() interface{} {
+	switch lf.fieldType {
+	case stringType:
+		return lf.stringVal
+	case boolType:
+		return lf.numericVal != 0
+	case intType:
+		return int(lf.numericVal)
+	case int32Type:
+		return int32(lf.numericVal)
+	case int64Type:
+		return int64(lf.numericVal)
+	case uint32Type:
+		return uint32(lf.numericVal)
+	case uint64Type:
+		return uint64(lf.numericVal)
+	case float32Type:
+		return math.Float32frombits(uint32(lf.numericVal))
+	case float64Type:
+		return math.Float64frombits(uint64(lf.numericVal))
+	case errorType, objectType, lazyLoggerType:
+		return lf.interfaceVal
+	case noopType:
+		return nil
+	default:
+		return nil
+	}
+}
+
+// String returns a string representation of the key and value.
+func (lf Field) String() string {
+	return fmt.Sprint(lf.key, ":", lf.Value())
+}

--- a/vendor/github.com/opentracing/opentracing-go/log/util.go
+++ b/vendor/github.com/opentracing/opentracing-go/log/util.go
@@ -1,0 +1,54 @@
+package log
+
+import "fmt"
+
+// InterleavedKVToFields converts keyValues a la Span.LogKV() to a Field slice
+// a la Span.LogFields().
+func InterleavedKVToFields(keyValues ...interface{}) ([]Field, error) {
+	if len(keyValues)%2 != 0 {
+		return nil, fmt.Errorf("non-even keyValues len: %d", len(keyValues))
+	}
+	fields := make([]Field, len(keyValues)/2)
+	for i := 0; i*2 < len(keyValues); i++ {
+		key, ok := keyValues[i*2].(string)
+		if !ok {
+			return nil, fmt.Errorf(
+				"non-string key (pair #%d): %T",
+				i, keyValues[i*2])
+		}
+		switch typedVal := keyValues[i*2+1].(type) {
+		case bool:
+			fields[i] = Bool(key, typedVal)
+		case string:
+			fields[i] = String(key, typedVal)
+		case int:
+			fields[i] = Int(key, typedVal)
+		case int8:
+			fields[i] = Int32(key, int32(typedVal))
+		case int16:
+			fields[i] = Int32(key, int32(typedVal))
+		case int32:
+			fields[i] = Int32(key, typedVal)
+		case int64:
+			fields[i] = Int64(key, typedVal)
+		case uint:
+			fields[i] = Uint64(key, uint64(typedVal))
+		case uint64:
+			fields[i] = Uint64(key, typedVal)
+		case uint8:
+			fields[i] = Uint32(key, uint32(typedVal))
+		case uint16:
+			fields[i] = Uint32(key, uint32(typedVal))
+		case uint32:
+			fields[i] = Uint32(key, typedVal)
+		case float32:
+			fields[i] = Float32(key, typedVal)
+		case float64:
+			fields[i] = Float64(key, typedVal)
+		default:
+			// When in doubt, coerce to a string
+			fields[i] = String(key, fmt.Sprint(typedVal))
+		}
+	}
+	return fields, nil
+}

--- a/vendor/github.com/opentracing/opentracing-go/noop.go
+++ b/vendor/github.com/opentracing/opentracing-go/noop.go
@@ -1,0 +1,64 @@
+package opentracing
+
+import "github.com/opentracing/opentracing-go/log"
+
+// A NoopTracer is a trivial, minimum overhead implementation of Tracer
+// for which all operations are no-ops.
+//
+// The primary use of this implementation is in libraries, such as RPC
+// frameworks, that make tracing an optional feature controlled by the
+// end user. A no-op implementation allows said libraries to use it
+// as the default Tracer and to write instrumentation that does
+// not need to keep checking if the tracer instance is nil.
+//
+// For the same reason, the NoopTracer is the default "global" tracer
+// (see GlobalTracer and SetGlobalTracer functions).
+//
+// WARNING: NoopTracer does not support baggage propagation.
+type NoopTracer struct{}
+
+type noopSpan struct{}
+type noopSpanContext struct{}
+
+var (
+	defaultNoopSpanContext = noopSpanContext{}
+	defaultNoopSpan        = noopSpan{}
+	defaultNoopTracer      = NoopTracer{}
+)
+
+const (
+	emptyString = ""
+)
+
+// noopSpanContext:
+func (n noopSpanContext) ForeachBaggageItem(handler func(k, v string) bool) {}
+
+// noopSpan:
+func (n noopSpan) Context() SpanContext                                  { return defaultNoopSpanContext }
+func (n noopSpan) SetBaggageItem(key, val string) Span                   { return defaultNoopSpan }
+func (n noopSpan) BaggageItem(key string) string                         { return emptyString }
+func (n noopSpan) SetTag(key string, value interface{}) Span             { return n }
+func (n noopSpan) LogFields(fields ...log.Field)                         {}
+func (n noopSpan) LogKV(keyVals ...interface{})                          {}
+func (n noopSpan) Finish()                                               {}
+func (n noopSpan) FinishWithOptions(opts FinishOptions)                  {}
+func (n noopSpan) SetOperationName(operationName string) Span            { return n }
+func (n noopSpan) Tracer() Tracer                                        { return defaultNoopTracer }
+func (n noopSpan) LogEvent(event string)                                 {}
+func (n noopSpan) LogEventWithPayload(event string, payload interface{}) {}
+func (n noopSpan) Log(data LogData)                                      {}
+
+// StartSpan belongs to the Tracer interface.
+func (n NoopTracer) StartSpan(operationName string, opts ...StartSpanOption) Span {
+	return defaultNoopSpan
+}
+
+// Inject belongs to the Tracer interface.
+func (n NoopTracer) Inject(sp SpanContext, format interface{}, carrier interface{}) error {
+	return nil
+}
+
+// Extract belongs to the Tracer interface.
+func (n NoopTracer) Extract(format interface{}, carrier interface{}) (SpanContext, error) {
+	return nil, ErrSpanContextNotFound
+}

--- a/vendor/github.com/opentracing/opentracing-go/propagation.go
+++ b/vendor/github.com/opentracing/opentracing-go/propagation.go
@@ -1,0 +1,176 @@
+package opentracing
+
+import (
+	"errors"
+	"net/http"
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// CORE PROPAGATION INTERFACES:
+///////////////////////////////////////////////////////////////////////////////
+
+var (
+	// ErrUnsupportedFormat occurs when the `format` passed to Tracer.Inject() or
+	// Tracer.Extract() is not recognized by the Tracer implementation.
+	ErrUnsupportedFormat = errors.New("opentracing: Unknown or unsupported Inject/Extract format")
+
+	// ErrSpanContextNotFound occurs when the `carrier` passed to
+	// Tracer.Extract() is valid and uncorrupted but has insufficient
+	// information to extract a SpanContext.
+	ErrSpanContextNotFound = errors.New("opentracing: SpanContext not found in Extract carrier")
+
+	// ErrInvalidSpanContext errors occur when Tracer.Inject() is asked to
+	// operate on a SpanContext which it is not prepared to handle (for
+	// example, since it was created by a different tracer implementation).
+	ErrInvalidSpanContext = errors.New("opentracing: SpanContext type incompatible with tracer")
+
+	// ErrInvalidCarrier errors occur when Tracer.Inject() or Tracer.Extract()
+	// implementations expect a different type of `carrier` than they are
+	// given.
+	ErrInvalidCarrier = errors.New("opentracing: Invalid Inject/Extract carrier")
+
+	// ErrSpanContextCorrupted occurs when the `carrier` passed to
+	// Tracer.Extract() is of the expected type but is corrupted.
+	ErrSpanContextCorrupted = errors.New("opentracing: SpanContext data corrupted in Extract carrier")
+)
+
+///////////////////////////////////////////////////////////////////////////////
+// BUILTIN PROPAGATION FORMATS:
+///////////////////////////////////////////////////////////////////////////////
+
+// BuiltinFormat is used to demarcate the values within package `opentracing`
+// that are intended for use with the Tracer.Inject() and Tracer.Extract()
+// methods.
+type BuiltinFormat byte
+
+const (
+	// Binary represents SpanContexts as opaque binary data.
+	//
+	// For Tracer.Inject(): the carrier must be an `io.Writer`.
+	//
+	// For Tracer.Extract(): the carrier must be an `io.Reader`.
+	Binary BuiltinFormat = iota
+
+	// TextMap represents SpanContexts as key:value string pairs.
+	//
+	// Unlike HTTPHeaders, the TextMap format does not restrict the key or
+	// value character sets in any way.
+	//
+	// For Tracer.Inject(): the carrier must be a `TextMapWriter`.
+	//
+	// For Tracer.Extract(): the carrier must be a `TextMapReader`.
+	TextMap
+
+	// HTTPHeaders represents SpanContexts as HTTP header string pairs.
+	//
+	// Unlike TextMap, the HTTPHeaders format requires that the keys and values
+	// be valid as HTTP headers as-is (i.e., character casing may be unstable
+	// and special characters are disallowed in keys, values should be
+	// URL-escaped, etc).
+	//
+	// For Tracer.Inject(): the carrier must be a `TextMapWriter`.
+	//
+	// For Tracer.Extract(): the carrier must be a `TextMapReader`.
+	//
+	// See HTTPHeadersCarrier for an implementation of both TextMapWriter
+	// and TextMapReader that defers to an http.Header instance for storage.
+	// For example, Inject():
+	//
+	//    carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+	//    err := span.Tracer().Inject(
+	//        span.Context(), opentracing.HTTPHeaders, carrier)
+	//
+	// Or Extract():
+	//
+	//    carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+	//    clientContext, err := tracer.Extract(
+	//        opentracing.HTTPHeaders, carrier)
+	//
+	HTTPHeaders
+)
+
+// TextMapWriter is the Inject() carrier for the TextMap builtin format. With
+// it, the caller can encode a SpanContext for propagation as entries in a map
+// of unicode strings.
+type TextMapWriter interface {
+	// Set a key:value pair to the carrier. Multiple calls to Set() for the
+	// same key leads to undefined behavior.
+	//
+	// NOTE: The backing store for the TextMapWriter may contain data unrelated
+	// to SpanContext. As such, Inject() and Extract() implementations that
+	// call the TextMapWriter and TextMapReader interfaces must agree on a
+	// prefix or other convention to distinguish their own key:value pairs.
+	Set(key, val string)
+}
+
+// TextMapReader is the Extract() carrier for the TextMap builtin format. With it,
+// the caller can decode a propagated SpanContext as entries in a map of
+// unicode strings.
+type TextMapReader interface {
+	// ForeachKey returns TextMap contents via repeated calls to the `handler`
+	// function. If any call to `handler` returns a non-nil error, ForeachKey
+	// terminates and returns that error.
+	//
+	// NOTE: The backing store for the TextMapReader may contain data unrelated
+	// to SpanContext. As such, Inject() and Extract() implementations that
+	// call the TextMapWriter and TextMapReader interfaces must agree on a
+	// prefix or other convention to distinguish their own key:value pairs.
+	//
+	// The "foreach" callback pattern reduces unnecessary copying in some cases
+	// and also allows implementations to hold locks while the map is read.
+	ForeachKey(handler func(key, val string) error) error
+}
+
+// TextMapCarrier allows the use of regular map[string]string
+// as both TextMapWriter and TextMapReader.
+type TextMapCarrier map[string]string
+
+// ForeachKey conforms to the TextMapReader interface.
+func (c TextMapCarrier) ForeachKey(handler func(key, val string) error) error {
+	for k, v := range c {
+		if err := handler(k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Set implements Set() of opentracing.TextMapWriter
+func (c TextMapCarrier) Set(key, val string) {
+	c[key] = val
+}
+
+// HTTPHeadersCarrier satisfies both TextMapWriter and TextMapReader.
+//
+// Example usage for server side:
+//
+//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+//     clientContext, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
+//
+// Example usage for client side:
+//
+//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+//     err := tracer.Inject(
+//         span.Context(),
+//         opentracing.HTTPHeaders,
+//         carrier)
+//
+type HTTPHeadersCarrier http.Header
+
+// Set conforms to the TextMapWriter interface.
+func (c HTTPHeadersCarrier) Set(key, val string) {
+	h := http.Header(c)
+	h.Set(key, val)
+}
+
+// ForeachKey conforms to the TextMapReader interface.
+func (c HTTPHeadersCarrier) ForeachKey(handler func(key, val string) error) error {
+	for k, vals := range c {
+		for _, v := range vals {
+			if err := handler(k, v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/vendor/github.com/opentracing/opentracing-go/span.go
+++ b/vendor/github.com/opentracing/opentracing-go/span.go
@@ -1,0 +1,189 @@
+package opentracing
+
+import (
+	"time"
+
+	"github.com/opentracing/opentracing-go/log"
+)
+
+// SpanContext represents Span state that must propagate to descendant Spans and across process
+// boundaries (e.g., a <trace_id, span_id, sampled> tuple).
+type SpanContext interface {
+	// ForeachBaggageItem grants access to all baggage items stored in the
+	// SpanContext.
+	// The handler function will be called for each baggage key/value pair.
+	// The ordering of items is not guaranteed.
+	//
+	// The bool return value indicates if the handler wants to continue iterating
+	// through the rest of the baggage items; for example if the handler is trying to
+	// find some baggage item by pattern matching the name, it can return false
+	// as soon as the item is found to stop further iterations.
+	ForeachBaggageItem(handler func(k, v string) bool)
+}
+
+// Span represents an active, un-finished span in the OpenTracing system.
+//
+// Spans are created by the Tracer interface.
+type Span interface {
+	// Sets the end timestamp and finalizes Span state.
+	//
+	// With the exception of calls to Context() (which are always allowed),
+	// Finish() must be the last call made to any span instance, and to do
+	// otherwise leads to undefined behavior.
+	Finish()
+	// FinishWithOptions is like Finish() but with explicit control over
+	// timestamps and log data.
+	FinishWithOptions(opts FinishOptions)
+
+	// Context() yields the SpanContext for this Span. Note that the return
+	// value of Context() is still valid after a call to Span.Finish(), as is
+	// a call to Span.Context() after a call to Span.Finish().
+	Context() SpanContext
+
+	// Sets or changes the operation name.
+	//
+	// Returns a reference to this Span for chaining.
+	SetOperationName(operationName string) Span
+
+	// Adds a tag to the span.
+	//
+	// If there is a pre-existing tag set for `key`, it is overwritten.
+	//
+	// Tag values can be numeric types, strings, or bools. The behavior of
+	// other tag value types is undefined at the OpenTracing level. If a
+	// tracing system does not know how to handle a particular value type, it
+	// may ignore the tag, but shall not panic.
+	//
+	// Returns a reference to this Span for chaining.
+	SetTag(key string, value interface{}) Span
+
+	// LogFields is an efficient and type-checked way to record key:value
+	// logging data about a Span, though the programming interface is a little
+	// more verbose than LogKV(). Here's an example:
+	//
+	//    span.LogFields(
+	//        log.String("event", "soft error"),
+	//        log.String("type", "cache timeout"),
+	//        log.Int("waited.millis", 1500))
+	//
+	// Also see Span.FinishWithOptions() and FinishOptions.BulkLogData.
+	LogFields(fields ...log.Field)
+
+	// LogKV is a concise, readable way to record key:value logging data about
+	// a Span, though unfortunately this also makes it less efficient and less
+	// type-safe than LogFields(). Here's an example:
+	//
+	//    span.LogKV(
+	//        "event", "soft error",
+	//        "type", "cache timeout",
+	//        "waited.millis", 1500)
+	//
+	// For LogKV (as opposed to LogFields()), the parameters must appear as
+	// key-value pairs, like
+	//
+	//    span.LogKV(key1, val1, key2, val2, key3, val3, ...)
+	//
+	// The keys must all be strings. The values may be strings, numeric types,
+	// bools, Go error instances, or arbitrary structs.
+	//
+	// (Note to implementors: consider the log.InterleavedKVToFields() helper)
+	LogKV(alternatingKeyValues ...interface{})
+
+	// SetBaggageItem sets a key:value pair on this Span and its SpanContext
+	// that also propagates to descendants of this Span.
+	//
+	// SetBaggageItem() enables powerful functionality given a full-stack
+	// opentracing integration (e.g., arbitrary application data from a mobile
+	// app can make it, transparently, all the way into the depths of a storage
+	// system), and with it some powerful costs: use this feature with care.
+	//
+	// IMPORTANT NOTE #1: SetBaggageItem() will only propagate baggage items to
+	// *future* causal descendants of the associated Span.
+	//
+	// IMPORTANT NOTE #2: Use this thoughtfully and with care. Every key and
+	// value is copied into every local *and remote* child of the associated
+	// Span, and that can add up to a lot of network and cpu overhead.
+	//
+	// Returns a reference to this Span for chaining.
+	SetBaggageItem(restrictedKey, value string) Span
+
+	// Gets the value for a baggage item given its key. Returns the empty string
+	// if the value isn't found in this Span.
+	BaggageItem(restrictedKey string) string
+
+	// Provides access to the Tracer that created this Span.
+	Tracer() Tracer
+
+	// Deprecated: use LogFields or LogKV
+	LogEvent(event string)
+	// Deprecated: use LogFields or LogKV
+	LogEventWithPayload(event string, payload interface{})
+	// Deprecated: use LogFields or LogKV
+	Log(data LogData)
+}
+
+// LogRecord is data associated with a single Span log. Every LogRecord
+// instance must specify at least one Field.
+type LogRecord struct {
+	Timestamp time.Time
+	Fields    []log.Field
+}
+
+// FinishOptions allows Span.FinishWithOptions callers to override the finish
+// timestamp and provide log data via a bulk interface.
+type FinishOptions struct {
+	// FinishTime overrides the Span's finish time, or implicitly becomes
+	// time.Now() if FinishTime.IsZero().
+	//
+	// FinishTime must resolve to a timestamp that's >= the Span's StartTime
+	// (per StartSpanOptions).
+	FinishTime time.Time
+
+	// LogRecords allows the caller to specify the contents of many LogFields()
+	// calls with a single slice. May be nil.
+	//
+	// None of the LogRecord.Timestamp values may be .IsZero() (i.e., they must
+	// be set explicitly). Also, they must be >= the Span's start timestamp and
+	// <= the FinishTime (or time.Now() if FinishTime.IsZero()). Otherwise the
+	// behavior of FinishWithOptions() is undefined.
+	//
+	// If specified, the caller hands off ownership of LogRecords at
+	// FinishWithOptions() invocation time.
+	//
+	// If specified, the (deprecated) BulkLogData must be nil or empty.
+	LogRecords []LogRecord
+
+	// BulkLogData is DEPRECATED.
+	BulkLogData []LogData
+}
+
+// LogData is DEPRECATED
+type LogData struct {
+	Timestamp time.Time
+	Event     string
+	Payload   interface{}
+}
+
+// ToLogRecord converts a deprecated LogData to a non-deprecated LogRecord
+func (ld *LogData) ToLogRecord() LogRecord {
+	var literalTimestamp time.Time
+	if ld.Timestamp.IsZero() {
+		literalTimestamp = time.Now()
+	} else {
+		literalTimestamp = ld.Timestamp
+	}
+	rval := LogRecord{
+		Timestamp: literalTimestamp,
+	}
+	if ld.Payload == nil {
+		rval.Fields = []log.Field{
+			log.String("event", ld.Event),
+		}
+	} else {
+		rval.Fields = []log.Field{
+			log.String("event", ld.Event),
+			log.Object("payload", ld.Payload),
+		}
+	}
+	return rval
+}

--- a/vendor/github.com/opentracing/opentracing-go/tracer.go
+++ b/vendor/github.com/opentracing/opentracing-go/tracer.go
@@ -1,0 +1,304 @@
+package opentracing
+
+import "time"
+
+// Tracer is a simple, thin interface for Span creation and SpanContext
+// propagation.
+type Tracer interface {
+
+	// Create, start, and return a new Span with the given `operationName` and
+	// incorporate the given StartSpanOption `opts`. (Note that `opts` borrows
+	// from the "functional options" pattern, per
+	// http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis)
+	//
+	// A Span with no SpanReference options (e.g., opentracing.ChildOf() or
+	// opentracing.FollowsFrom()) becomes the root of its own trace.
+	//
+	// Examples:
+	//
+	//     var tracer opentracing.Tracer = ...
+	//
+	//     // The root-span case:
+	//     sp := tracer.StartSpan("GetFeed")
+	//
+	//     // The vanilla child span case:
+	//     sp := tracer.StartSpan(
+	//         "GetFeed",
+	//         opentracing.ChildOf(parentSpan.Context()))
+	//
+	//     // All the bells and whistles:
+	//     sp := tracer.StartSpan(
+	//         "GetFeed",
+	//         opentracing.ChildOf(parentSpan.Context()),
+	//         opentracing.Tag{"user_agent", loggedReq.UserAgent},
+	//         opentracing.StartTime(loggedReq.Timestamp),
+	//     )
+	//
+	StartSpan(operationName string, opts ...StartSpanOption) Span
+
+	// Inject() takes the `sm` SpanContext instance and injects it for
+	// propagation within `carrier`. The actual type of `carrier` depends on
+	// the value of `format`.
+	//
+	// OpenTracing defines a common set of `format` values (see BuiltinFormat),
+	// and each has an expected carrier type.
+	//
+	// Other packages may declare their own `format` values, much like the keys
+	// used by `context.Context` (see https://godoc.org/context#WithValue).
+	//
+	// Example usage (sans error handling):
+	//
+	//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+	//     err := tracer.Inject(
+	//         span.Context(),
+	//         opentracing.HTTPHeaders,
+	//         carrier)
+	//
+	// NOTE: All opentracing.Tracer implementations MUST support all
+	// BuiltinFormats.
+	//
+	// Implementations may return opentracing.ErrUnsupportedFormat if `format`
+	// is not supported by (or not known by) the implementation.
+	//
+	// Implementations may return opentracing.ErrInvalidCarrier or any other
+	// implementation-specific error if the format is supported but injection
+	// fails anyway.
+	//
+	// See Tracer.Extract().
+	Inject(sm SpanContext, format interface{}, carrier interface{}) error
+
+	// Extract() returns a SpanContext instance given `format` and `carrier`.
+	//
+	// OpenTracing defines a common set of `format` values (see BuiltinFormat),
+	// and each has an expected carrier type.
+	//
+	// Other packages may declare their own `format` values, much like the keys
+	// used by `context.Context` (see
+	// https://godoc.org/golang.org/x/net/context#WithValue).
+	//
+	// Example usage (with StartSpan):
+	//
+	//
+	//     carrier := opentracing.HTTPHeadersCarrier(httpReq.Header)
+	//     clientContext, err := tracer.Extract(opentracing.HTTPHeaders, carrier)
+	//
+	//     // ... assuming the ultimate goal here is to resume the trace with a
+	//     // server-side Span:
+	//     var serverSpan opentracing.Span
+	//     if err == nil {
+	//         span = tracer.StartSpan(
+	//             rpcMethodName, ext.RPCServerOption(clientContext))
+	//     } else {
+	//         span = tracer.StartSpan(rpcMethodName)
+	//     }
+	//
+	//
+	// NOTE: All opentracing.Tracer implementations MUST support all
+	// BuiltinFormats.
+	//
+	// Return values:
+	//  - A successful Extract returns a SpanContext instance and a nil error
+	//  - If there was simply no SpanContext to extract in `carrier`, Extract()
+	//    returns (nil, opentracing.ErrSpanContextNotFound)
+	//  - If `format` is unsupported or unrecognized, Extract() returns (nil,
+	//    opentracing.ErrUnsupportedFormat)
+	//  - If there are more fundamental problems with the `carrier` object,
+	//    Extract() may return opentracing.ErrInvalidCarrier,
+	//    opentracing.ErrSpanContextCorrupted, or implementation-specific
+	//    errors.
+	//
+	// See Tracer.Inject().
+	Extract(format interface{}, carrier interface{}) (SpanContext, error)
+}
+
+// StartSpanOptions allows Tracer.StartSpan() callers and implementors a
+// mechanism to override the start timestamp, specify Span References, and make
+// a single Tag or multiple Tags available at Span start time.
+//
+// StartSpan() callers should look at the StartSpanOption interface and
+// implementations available in this package.
+//
+// Tracer implementations can convert a slice of `StartSpanOption` instances
+// into a `StartSpanOptions` struct like so:
+//
+//     func StartSpan(opName string, opts ...opentracing.StartSpanOption) {
+//         sso := opentracing.StartSpanOptions{}
+//         for _, o := range opts {
+//             o.Apply(&sso)
+//         }
+//         ...
+//     }
+//
+type StartSpanOptions struct {
+	// Zero or more causal references to other Spans (via their SpanContext).
+	// If empty, start a "root" Span (i.e., start a new trace).
+	References []SpanReference
+
+	// StartTime overrides the Span's start time, or implicitly becomes
+	// time.Now() if StartTime.IsZero().
+	StartTime time.Time
+
+	// Tags may have zero or more entries; the restrictions on map values are
+	// identical to those for Span.SetTag(). May be nil.
+	//
+	// If specified, the caller hands off ownership of Tags at
+	// StartSpan() invocation time.
+	Tags map[string]interface{}
+}
+
+// StartSpanOption instances (zero or more) may be passed to Tracer.StartSpan.
+//
+// StartSpanOption borrows from the "functional options" pattern, per
+// http://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis
+type StartSpanOption interface {
+	Apply(*StartSpanOptions)
+}
+
+// SpanReferenceType is an enum type describing different categories of
+// relationships between two Spans. If Span-2 refers to Span-1, the
+// SpanReferenceType describes Span-1 from Span-2's perspective. For example,
+// ChildOfRef means that Span-1 created Span-2.
+//
+// NOTE: Span-1 and Span-2 do *not* necessarily depend on each other for
+// completion; e.g., Span-2 may be part of a background job enqueued by Span-1,
+// or Span-2 may be sitting in a distributed queue behind Span-1.
+type SpanReferenceType int
+
+const (
+	// ChildOfRef refers to a parent Span that caused *and* somehow depends
+	// upon the new child Span. Often (but not always), the parent Span cannot
+	// finish until the child Span does.
+	//
+	// An timing diagram for a ChildOfRef that's blocked on the new Span:
+	//
+	//     [-Parent Span---------]
+	//          [-Child Span----]
+	//
+	// See http://opentracing.io/spec/
+	//
+	// See opentracing.ChildOf()
+	ChildOfRef SpanReferenceType = iota
+
+	// FollowsFromRef refers to a parent Span that does not depend in any way
+	// on the result of the new child Span. For instance, one might use
+	// FollowsFromRefs to describe pipeline stages separated by queues,
+	// or a fire-and-forget cache insert at the tail end of a web request.
+	//
+	// A FollowsFromRef Span is part of the same logical trace as the new Span:
+	// i.e., the new Span is somehow caused by the work of its FollowsFromRef.
+	//
+	// All of the following could be valid timing diagrams for children that
+	// "FollowFrom" a parent.
+	//
+	//     [-Parent Span-]  [-Child Span-]
+	//
+	//
+	//     [-Parent Span--]
+	//      [-Child Span-]
+	//
+	//
+	//     [-Parent Span-]
+	//                 [-Child Span-]
+	//
+	// See http://opentracing.io/spec/
+	//
+	// See opentracing.FollowsFrom()
+	FollowsFromRef
+)
+
+// SpanReference is a StartSpanOption that pairs a SpanReferenceType and a
+// referenced SpanContext. See the SpanReferenceType documentation for
+// supported relationships.  If SpanReference is created with
+// ReferencedContext==nil, it has no effect. Thus it allows for a more concise
+// syntax for starting spans:
+//
+//     sc, _ := tracer.Extract(someFormat, someCarrier)
+//     span := tracer.StartSpan("operation", opentracing.ChildOf(sc))
+//
+// The `ChildOf(sc)` option above will not panic if sc == nil, it will just
+// not add the parent span reference to the options.
+type SpanReference struct {
+	Type              SpanReferenceType
+	ReferencedContext SpanContext
+}
+
+// Apply satisfies the StartSpanOption interface.
+func (r SpanReference) Apply(o *StartSpanOptions) {
+	if r.ReferencedContext != nil {
+		o.References = append(o.References, r)
+	}
+}
+
+// ChildOf returns a StartSpanOption pointing to a dependent parent span.
+// If sc == nil, the option has no effect.
+//
+// See ChildOfRef, SpanReference
+func ChildOf(sc SpanContext) SpanReference {
+	return SpanReference{
+		Type:              ChildOfRef,
+		ReferencedContext: sc,
+	}
+}
+
+// FollowsFrom returns a StartSpanOption pointing to a parent Span that caused
+// the child Span but does not directly depend on its result in any way.
+// If sc == nil, the option has no effect.
+//
+// See FollowsFromRef, SpanReference
+func FollowsFrom(sc SpanContext) SpanReference {
+	return SpanReference{
+		Type:              FollowsFromRef,
+		ReferencedContext: sc,
+	}
+}
+
+// StartTime is a StartSpanOption that sets an explicit start timestamp for the
+// new Span.
+type StartTime time.Time
+
+// Apply satisfies the StartSpanOption interface.
+func (t StartTime) Apply(o *StartSpanOptions) {
+	o.StartTime = time.Time(t)
+}
+
+// Tags are a generic map from an arbitrary string key to an opaque value type.
+// The underlying tracing system is responsible for interpreting and
+// serializing the values.
+type Tags map[string]interface{}
+
+// Apply satisfies the StartSpanOption interface.
+func (t Tags) Apply(o *StartSpanOptions) {
+	if o.Tags == nil {
+		o.Tags = make(map[string]interface{})
+	}
+	for k, v := range t {
+		o.Tags[k] = v
+	}
+}
+
+// Tag may be passed as a StartSpanOption to add a tag to new spans,
+// or its Set method may be used to apply the tag to an existing Span,
+// for example:
+//
+// tracer.StartSpan("opName", Tag{"Key", value})
+//
+//   or
+//
+// Tag{"key", value}.Set(span)
+type Tag struct {
+	Key   string
+	Value interface{}
+}
+
+// Apply satisfies the StartSpanOption interface.
+func (t Tag) Apply(o *StartSpanOptions) {
+	if o.Tags == nil {
+		o.Tags = make(map[string]interface{})
+	}
+	o.Tags[t.Key] = t.Value
+}
+
+// Set applies the tag to an existing Span.
+func (t Tag) Set(s Span) {
+	s.SetTag(t.Key, t.Value)
+}

--- a/vendor/github.com/prometheus/prometheus/promql/ast.go
+++ b/vendor/github.com/prometheus/prometheus/promql/ast.go
@@ -1,0 +1,316 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
+)
+
+// Node is a generic interface for all nodes in an AST.
+//
+// Whenever numerous nodes are listed such as in a switch-case statement
+// or a chain of function definitions (e.g. String(), expr(), etc.) convention is
+// to list them as follows:
+//
+// 	- Statements
+// 	- statement types (alphabetical)
+// 	- ...
+// 	- Expressions
+// 	- expression types (alphabetical)
+// 	- ...
+//
+type Node interface {
+	// String representation of the node that returns the given node when parsed
+	// as part of a valid query.
+	String() string
+}
+
+// Statement is a generic interface for all statements.
+type Statement interface {
+	Node
+
+	// stmt ensures that no other type accidentally implements the interface
+	stmt()
+}
+
+// Statements is a list of statement nodes that implements Node.
+type Statements []Statement
+
+// AlertStmt represents an added alert rule.
+type AlertStmt struct {
+	Name        string
+	Expr        Expr
+	Duration    time.Duration
+	Labels      labels.Labels
+	Annotations labels.Labels
+}
+
+// EvalStmt holds an expression and information on the range it should
+// be evaluated on.
+type EvalStmt struct {
+	Expr Expr // Expression to be evaluated.
+
+	// The time boundaries for the evaluation. If Start equals End an instant
+	// is evaluated.
+	Start, End time.Time
+	// Time between two evaluated instants for the range [Start:End].
+	Interval time.Duration
+}
+
+// RecordStmt represents an added recording rule.
+type RecordStmt struct {
+	Name   string
+	Expr   Expr
+	Labels labels.Labels
+}
+
+func (*AlertStmt) stmt()  {}
+func (*EvalStmt) stmt()   {}
+func (*RecordStmt) stmt() {}
+
+// Expr is a generic interface for all expression types.
+type Expr interface {
+	Node
+
+	// Type returns the type the expression evaluates to. It does not perform
+	// in-depth checks as this is done at parsing-time.
+	Type() ValueType
+	// expr ensures that no other types accidentally implement the interface.
+	expr()
+}
+
+// Expressions is a list of expression nodes that implements Node.
+type Expressions []Expr
+
+// AggregateExpr represents an aggregation operation on a Vector.
+type AggregateExpr struct {
+	Op       ItemType // The used aggregation operation.
+	Expr     Expr     // The Vector expression over which is aggregated.
+	Param    Expr     // Parameter used by some aggregators.
+	Grouping []string // The labels by which to group the Vector.
+	Without  bool     // Whether to drop the given labels rather than keep them.
+}
+
+// BinaryExpr represents a binary expression between two child expressions.
+type BinaryExpr struct {
+	Op       ItemType // The operation of the expression.
+	LHS, RHS Expr     // The operands on the respective sides of the operator.
+
+	// The matching behavior for the operation if both operands are Vectors.
+	// If they are not this field is nil.
+	VectorMatching *VectorMatching
+
+	// If a comparison operator, return 0/1 rather than filtering.
+	ReturnBool bool
+}
+
+// Call represents a function call.
+type Call struct {
+	Func *Function   // The function that was called.
+	Args Expressions // Arguments used in the call.
+}
+
+// MatrixSelector represents a Matrix selection.
+type MatrixSelector struct {
+	Name          string
+	Range         time.Duration
+	Offset        time.Duration
+	LabelMatchers []*labels.Matcher
+
+	// The series are populated at query preparation time.
+	series []storage.Series
+}
+
+// NumberLiteral represents a number.
+type NumberLiteral struct {
+	Val float64
+}
+
+// ParenExpr wraps an expression so it cannot be disassembled as a consequence
+// of operator precedence.
+type ParenExpr struct {
+	Expr Expr
+}
+
+// StringLiteral represents a string.
+type StringLiteral struct {
+	Val string
+}
+
+// UnaryExpr represents a unary operation on another expression.
+// Currently unary operations are only supported for Scalars.
+type UnaryExpr struct {
+	Op   ItemType
+	Expr Expr
+}
+
+// VectorSelector represents a Vector selection.
+type VectorSelector struct {
+	Name          string
+	Offset        time.Duration
+	LabelMatchers []*labels.Matcher
+
+	// The series are populated at query preparation time.
+	series []storage.Series
+}
+
+func (e *AggregateExpr) Type() ValueType  { return ValueTypeVector }
+func (e *Call) Type() ValueType           { return e.Func.ReturnType }
+func (e *MatrixSelector) Type() ValueType { return ValueTypeMatrix }
+func (e *NumberLiteral) Type() ValueType  { return ValueTypeScalar }
+func (e *ParenExpr) Type() ValueType      { return e.Expr.Type() }
+func (e *StringLiteral) Type() ValueType  { return ValueTypeString }
+func (e *UnaryExpr) Type() ValueType      { return e.Expr.Type() }
+func (e *VectorSelector) Type() ValueType { return ValueTypeVector }
+func (e *BinaryExpr) Type() ValueType {
+	if e.LHS.Type() == ValueTypeScalar && e.RHS.Type() == ValueTypeScalar {
+		return ValueTypeScalar
+	}
+	return ValueTypeVector
+}
+
+func (*AggregateExpr) expr()  {}
+func (*BinaryExpr) expr()     {}
+func (*Call) expr()           {}
+func (*MatrixSelector) expr() {}
+func (*NumberLiteral) expr()  {}
+func (*ParenExpr) expr()      {}
+func (*StringLiteral) expr()  {}
+func (*UnaryExpr) expr()      {}
+func (*VectorSelector) expr() {}
+
+// VectorMatchCardinality describes the cardinality relationship
+// of two Vectors in a binary operation.
+type VectorMatchCardinality int
+
+const (
+	CardOneToOne VectorMatchCardinality = iota
+	CardManyToOne
+	CardOneToMany
+	CardManyToMany
+)
+
+func (vmc VectorMatchCardinality) String() string {
+	switch vmc {
+	case CardOneToOne:
+		return "one-to-one"
+	case CardManyToOne:
+		return "many-to-one"
+	case CardOneToMany:
+		return "one-to-many"
+	case CardManyToMany:
+		return "many-to-many"
+	}
+	panic("promql.VectorMatchCardinality.String: unknown match cardinality")
+}
+
+// VectorMatching describes how elements from two Vectors in a binary
+// operation are supposed to be matched.
+type VectorMatching struct {
+	// The cardinality of the two Vectors.
+	Card VectorMatchCardinality
+	// MatchingLabels contains the labels which define equality of a pair of
+	// elements from the Vectors.
+	MatchingLabels []string
+	// On includes the given label names from matching,
+	// rather than excluding them.
+	On bool
+	// Include contains additional labels that should be included in
+	// the result from the side with the lower cardinality.
+	Include []string
+}
+
+// Visitor allows visiting a Node and its child nodes. The Visit method is
+// invoked for each node with the path leading to the node provided additionally.
+// If the result visitor w is not nil, Walk visits each of the children
+// of node with the visitor w, followed by a call of w.Visit(nil, nil).
+type Visitor interface {
+	Visit(node Node, path []Node) (w Visitor)
+}
+
+// Walk traverses an AST in depth-first order: It starts by calling
+// v.Visit(node, path); node must not be nil. If the visitor w returned by
+// v.Visit(node, path) is not nil, Walk is invoked recursively with visitor
+// w for each of the non-nil children of node, followed by a call of
+// w.Visit(nil).
+// As the tree is descended the path of previous nodes is provided.
+func Walk(v Visitor, node Node, path []Node) {
+	if v = v.Visit(node, path); v == nil {
+		return
+	}
+	path = append(path, node)
+
+	switch n := node.(type) {
+	case Statements:
+		for _, s := range n {
+			Walk(v, s, path)
+		}
+	case *AlertStmt:
+		Walk(v, n.Expr, path)
+
+	case *EvalStmt:
+		Walk(v, n.Expr, path)
+
+	case *RecordStmt:
+		Walk(v, n.Expr, path)
+
+	case Expressions:
+		for _, e := range n {
+			Walk(v, e, path)
+		}
+	case *AggregateExpr:
+		Walk(v, n.Expr, path)
+
+	case *BinaryExpr:
+		Walk(v, n.LHS, path)
+		Walk(v, n.RHS, path)
+
+	case *Call:
+		Walk(v, n.Args, path)
+
+	case *ParenExpr:
+		Walk(v, n.Expr, path)
+
+	case *UnaryExpr:
+		Walk(v, n.Expr, path)
+
+	case *MatrixSelector, *NumberLiteral, *StringLiteral, *VectorSelector:
+		// nothing to do
+
+	default:
+		panic(fmt.Errorf("promql.Walk: unhandled node type %T", node))
+	}
+
+	v.Visit(nil, nil)
+}
+
+type inspector func(Node, []Node) bool
+
+func (f inspector) Visit(node Node, path []Node) Visitor {
+	if f(node, path) {
+		return f
+	}
+	return nil
+}
+
+// Inspect traverses an AST in depth-first order: It starts by calling
+// f(node, path); node must not be nil. If f returns true, Inspect invokes f
+// for all the non-nil children of node, recursively.
+func Inspect(node Node, f func(Node, []Node) bool) {
+	Walk(inspector(f), node, nil)
+}

--- a/vendor/github.com/prometheus/prometheus/promql/engine.go
+++ b/vendor/github.com/prometheus/prometheus/promql/engine.go
@@ -1,0 +1,1740 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"container/heap"
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"runtime"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/timestamp"
+	"github.com/prometheus/prometheus/pkg/value"
+	"github.com/prometheus/prometheus/storage"
+
+	"github.com/prometheus/prometheus/util/stats"
+)
+
+const (
+	namespace = "prometheus"
+	subsystem = "engine"
+	queryTag  = "query"
+
+	// The largest SampleValue that can be converted to an int64 without overflow.
+	maxInt64 = 9223372036854774784
+	// The smallest SampleValue that can be converted to an int64 without underflow.
+	minInt64 = -9223372036854775808
+)
+
+type engineMetrics struct {
+	currentQueries       prometheus.Gauge
+	maxConcurrentQueries prometheus.Gauge
+	queryQueueTime       prometheus.Summary
+	queryPrepareTime     prometheus.Summary
+	queryInnerEval       prometheus.Summary
+	queryResultSort      prometheus.Summary
+}
+
+// convertibleToInt64 returns true if v does not over-/underflow an int64.
+func convertibleToInt64(v float64) bool {
+	return v <= maxInt64 && v >= minInt64
+}
+
+type (
+	// ErrQueryTimeout is returned if a query timed out during processing.
+	ErrQueryTimeout string
+	// ErrQueryCanceled is returned if a query was canceled during processing.
+	ErrQueryCanceled string
+	// ErrStorage is returned if an error was encountered in the storage layer
+	// during query handling.
+	ErrStorage error
+)
+
+func (e ErrQueryTimeout) Error() string  { return fmt.Sprintf("query timed out in %s", string(e)) }
+func (e ErrQueryCanceled) Error() string { return fmt.Sprintf("query was canceled in %s", string(e)) }
+
+// A Query is derived from an a raw query string and can be run against an engine
+// it is associated with.
+type Query interface {
+	// Exec processes the query. Can only be called once.
+	Exec(ctx context.Context) *Result
+	// Close recovers memory used by the query result.
+	Close()
+	// Statement returns the parsed statement of the query.
+	Statement() Statement
+	// Stats returns statistics about the lifetime of the query.
+	Stats() *stats.TimerGroup
+	// Cancel signals that a running query execution should be aborted.
+	Cancel()
+}
+
+// query implements the Query interface.
+type query struct {
+	// Underlying data provider.
+	queryable storage.Queryable
+	// The original query string.
+	q string
+	// Statement of the parsed query.
+	stmt Statement
+	// Timer stats for the query execution.
+	stats *stats.TimerGroup
+	// Result matrix for reuse.
+	matrix Matrix
+	// Cancellation function for the query.
+	cancel func()
+
+	// The engine against which the query is executed.
+	ng *Engine
+}
+
+// Statement implements the Query interface.
+func (q *query) Statement() Statement {
+	return q.stmt
+}
+
+// Stats implements the Query interface.
+func (q *query) Stats() *stats.TimerGroup {
+	return q.stats
+}
+
+// Cancel implements the Query interface.
+func (q *query) Cancel() {
+	if q.cancel != nil {
+		q.cancel()
+	}
+}
+
+// Close implements the Query interface.
+func (q *query) Close() {
+	for _, s := range q.matrix {
+		putPointSlice(s.Points)
+	}
+}
+
+// Exec implements the Query interface.
+func (q *query) Exec(ctx context.Context) *Result {
+	if span := opentracing.SpanFromContext(ctx); span != nil {
+		span.SetTag(queryTag, q.stmt.String())
+	}
+
+	res, err := q.ng.exec(ctx, q)
+	return &Result{Err: err, Value: res}
+}
+
+// contextDone returns an error if the context was canceled or timed out.
+func contextDone(ctx context.Context, env string) error {
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		switch err {
+		case context.Canceled:
+			return ErrQueryCanceled(env)
+		case context.DeadlineExceeded:
+			return ErrQueryTimeout(env)
+		default:
+			return err
+		}
+	default:
+		return nil
+	}
+}
+
+// Engine handles the lifetime of queries from beginning to end.
+// It is connected to a querier.
+type Engine struct {
+	logger  log.Logger
+	metrics *engineMetrics
+	timeout time.Duration
+	gate    *queryGate
+}
+
+// NewEngine returns a new engine.
+func NewEngine(logger log.Logger, reg prometheus.Registerer, maxConcurrent int, timeout time.Duration) *Engine {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
+
+	metrics := &engineMetrics{
+		currentQueries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "queries",
+			Help:      "The current number of queries being executed or waiting.",
+		}),
+		maxConcurrentQueries: prometheus.NewGauge(prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "queries_concurrent_max",
+			Help:      "The max number of concurrent queries.",
+		}),
+		queryQueueTime: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "queue_time"},
+		}),
+		queryPrepareTime: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "prepare_time"},
+		}),
+		queryInnerEval: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "inner_eval"},
+		}),
+		queryResultSort: prometheus.NewSummary(prometheus.SummaryOpts{
+			Namespace:   namespace,
+			Subsystem:   subsystem,
+			Name:        "query_duration_seconds",
+			Help:        "Query timings",
+			ConstLabels: prometheus.Labels{"slice": "result_sort"},
+		}),
+	}
+	metrics.maxConcurrentQueries.Set(float64(maxConcurrent))
+
+	if reg != nil {
+		reg.MustRegister(
+			metrics.currentQueries,
+			metrics.maxConcurrentQueries,
+			metrics.queryInnerEval,
+			metrics.queryPrepareTime,
+			metrics.queryResultSort,
+		)
+	}
+	return &Engine{
+		gate:    newQueryGate(maxConcurrent),
+		timeout: timeout,
+		logger:  logger,
+		metrics: metrics,
+	}
+}
+
+// NewInstantQuery returns an evaluation query for the given expression at the given time.
+func (ng *Engine) NewInstantQuery(q storage.Queryable, qs string, ts time.Time) (Query, error) {
+	expr, err := ParseExpr(qs)
+	if err != nil {
+		return nil, err
+	}
+	qry := ng.newQuery(q, expr, ts, ts, 0)
+	qry.q = qs
+
+	return qry, nil
+}
+
+// NewRangeQuery returns an evaluation query for the given time range and with
+// the resolution set by the interval.
+func (ng *Engine) NewRangeQuery(q storage.Queryable, qs string, start, end time.Time, interval time.Duration) (Query, error) {
+	expr, err := ParseExpr(qs)
+	if err != nil {
+		return nil, err
+	}
+	if expr.Type() != ValueTypeVector && expr.Type() != ValueTypeScalar {
+		return nil, fmt.Errorf("invalid expression type %q for range query, must be Scalar or instant Vector", documentedType(expr.Type()))
+	}
+	qry := ng.newQuery(q, expr, start, end, interval)
+	qry.q = qs
+
+	return qry, nil
+}
+
+func (ng *Engine) newQuery(q storage.Queryable, expr Expr, start, end time.Time, interval time.Duration) *query {
+	es := &EvalStmt{
+		Expr:     expr,
+		Start:    start,
+		End:      end,
+		Interval: interval,
+	}
+	qry := &query{
+		stmt:      es,
+		ng:        ng,
+		stats:     stats.NewTimerGroup(),
+		queryable: q,
+	}
+	return qry
+}
+
+// testStmt is an internal helper statement that allows execution
+// of an arbitrary function during handling. It is used to test the Engine.
+type testStmt func(context.Context) error
+
+func (testStmt) String() string { return "test statement" }
+func (testStmt) stmt()          {}
+
+func (ng *Engine) newTestQuery(f func(context.Context) error) Query {
+	qry := &query{
+		q:     "test statement",
+		stmt:  testStmt(f),
+		ng:    ng,
+		stats: stats.NewTimerGroup(),
+	}
+	return qry
+}
+
+// exec executes the query.
+//
+// At this point per query only one EvalStmt is evaluated. Alert and record
+// statements are not handled by the Engine.
+func (ng *Engine) exec(ctx context.Context, q *query) (Value, error) {
+	ng.metrics.currentQueries.Inc()
+	defer ng.metrics.currentQueries.Dec()
+
+	ctx, cancel := context.WithTimeout(ctx, ng.timeout)
+	q.cancel = cancel
+
+	execTimer := q.stats.GetTimer(stats.ExecTotalTime).Start()
+	defer execTimer.Stop()
+	queueTimer := q.stats.GetTimer(stats.ExecQueueTime).Start()
+
+	if err := ng.gate.Start(ctx); err != nil {
+		return nil, err
+	}
+	defer ng.gate.Done()
+
+	queueTimer.Stop()
+	ng.metrics.queryQueueTime.Observe(queueTimer.ElapsedTime().Seconds())
+
+	// Cancel when execution is done or an error was raised.
+	defer q.cancel()
+
+	const env = "query execution"
+
+	evalTimer := q.stats.GetTimer(stats.EvalTotalTime).Start()
+	defer evalTimer.Stop()
+
+	// The base context might already be canceled on the first iteration (e.g. during shutdown).
+	if err := contextDone(ctx, env); err != nil {
+		return nil, err
+	}
+
+	switch s := q.Statement().(type) {
+	case *EvalStmt:
+		return ng.execEvalStmt(ctx, q, s)
+	case testStmt:
+		return nil, s(ctx)
+	}
+
+	panic(fmt.Errorf("promql.Engine.exec: unhandled statement of type %T", q.Statement()))
+}
+
+func timeMilliseconds(t time.Time) int64 {
+	return t.UnixNano() / int64(time.Millisecond/time.Nanosecond)
+}
+
+func durationMilliseconds(d time.Duration) int64 {
+	return int64(d / (time.Millisecond / time.Nanosecond))
+}
+
+// execEvalStmt evaluates the expression of an evaluation statement for the given time range.
+func (ng *Engine) execEvalStmt(ctx context.Context, query *query, s *EvalStmt) (Value, error) {
+	prepareTimer := query.stats.GetTimer(stats.QueryPreparationTime).Start()
+	querier, err := ng.populateSeries(ctx, query.queryable, s)
+	prepareTimer.Stop()
+	ng.metrics.queryPrepareTime.Observe(prepareTimer.ElapsedTime().Seconds())
+
+	// XXX(fabxc): the querier returned by populateSeries might be instantiated
+	// we must not return without closing irrespective of the error.
+	// TODO: make this semantically saner.
+	if querier != nil {
+		defer querier.Close()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	evalTimer := query.stats.GetTimer(stats.InnerEvalTime).Start()
+	// Instant evaluation. This is executed as a range evaluation with one step.
+	if s.Start == s.End && s.Interval == 0 {
+		start := timeMilliseconds(s.Start)
+		evaluator := &evaluator{
+			startTimestamp: start,
+			endTimestamp:   start,
+			interval:       1,
+			ctx:            ctx,
+			logger:         ng.logger,
+		}
+		val, err := evaluator.Eval(s.Expr)
+		if err != nil {
+			return nil, err
+		}
+
+		evalTimer.Stop()
+		ng.metrics.queryInnerEval.Observe(evalTimer.ElapsedTime().Seconds())
+
+		mat, ok := val.(Matrix)
+		if !ok {
+			panic(fmt.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
+		}
+		query.matrix = mat
+		switch s.Expr.Type() {
+		case ValueTypeVector:
+			// Convert matrix with one value per series into vector.
+			vector := make(Vector, len(mat))
+			for i, s := range mat {
+				// Point might have a different timestamp, force it to the evaluation
+				// timestamp as that is when we ran the evaluation.
+				vector[i] = Sample{Metric: s.Metric, Point: Point{V: s.Points[0].V, T: start}}
+			}
+			return vector, nil
+		case ValueTypeScalar:
+			return Scalar{V: mat[0].Points[0].V, T: start}, nil
+		case ValueTypeMatrix:
+			return mat, nil
+		default:
+			panic(fmt.Errorf("promql.Engine.exec: unexpected expression type %q", s.Expr.Type()))
+		}
+
+	}
+
+	// Range evaluation.
+	evaluator := &evaluator{
+		startTimestamp: timeMilliseconds(s.Start),
+		endTimestamp:   timeMilliseconds(s.End),
+		interval:       durationMilliseconds(s.Interval),
+		ctx:            ctx,
+		logger:         ng.logger,
+	}
+	val, err := evaluator.Eval(s.Expr)
+	if err != nil {
+		return nil, err
+	}
+	evalTimer.Stop()
+	ng.metrics.queryInnerEval.Observe(evalTimer.ElapsedTime().Seconds())
+
+	mat, ok := val.(Matrix)
+	if !ok {
+		panic(fmt.Errorf("promql.Engine.exec: invalid expression type %q", val.Type()))
+	}
+	query.matrix = mat
+
+	if err := contextDone(ctx, "expression evaluation"); err != nil {
+		return nil, err
+	}
+
+	// TODO(fabxc): order ensured by storage?
+	// TODO(fabxc): where to ensure metric labels are a copy from the storage internals.
+	sortTimer := query.stats.GetTimer(stats.ResultSortTime).Start()
+	sort.Sort(mat)
+	sortTimer.Stop()
+
+	ng.metrics.queryResultSort.Observe(sortTimer.ElapsedTime().Seconds())
+	return mat, nil
+}
+
+func (ng *Engine) populateSeries(ctx context.Context, q storage.Queryable, s *EvalStmt) (storage.Querier, error) {
+	var maxOffset time.Duration
+	Inspect(s.Expr, func(node Node, _ []Node) bool {
+		switch n := node.(type) {
+		case *VectorSelector:
+			if maxOffset < LookbackDelta {
+				maxOffset = LookbackDelta
+			}
+			if n.Offset+LookbackDelta > maxOffset {
+				maxOffset = n.Offset + LookbackDelta
+			}
+		case *MatrixSelector:
+			if maxOffset < n.Range {
+				maxOffset = n.Range
+			}
+			if n.Offset+n.Range > maxOffset {
+				maxOffset = n.Offset + n.Range
+			}
+		}
+		return true
+	})
+
+	mint := s.Start.Add(-maxOffset)
+
+	querier, err := q.Querier(ctx, timestamp.FromTime(mint), timestamp.FromTime(s.End))
+	if err != nil {
+		return nil, err
+	}
+
+	Inspect(s.Expr, func(node Node, path []Node) bool {
+		var set storage.SeriesSet
+		params := &storage.SelectParams{
+			Step: int64(s.Interval / time.Millisecond),
+		}
+
+		switch n := node.(type) {
+		case *VectorSelector:
+			params.Func = extractFuncFromPath(path)
+
+			set, err = querier.Select(params, n.LabelMatchers...)
+			if err != nil {
+				level.Error(ng.logger).Log("msg", "error selecting series set", "err", err)
+				return false
+			}
+			n.series, err = expandSeriesSet(set)
+			if err != nil {
+				// TODO(fabxc): use multi-error.
+				level.Error(ng.logger).Log("msg", "error expanding series set", "err", err)
+				return false
+			}
+
+		case *MatrixSelector:
+			params.Func = extractFuncFromPath(path)
+
+			set, err = querier.Select(params, n.LabelMatchers...)
+			if err != nil {
+				level.Error(ng.logger).Log("msg", "error selecting series set", "err", err)
+				return false
+			}
+			n.series, err = expandSeriesSet(set)
+			if err != nil {
+				level.Error(ng.logger).Log("msg", "error expanding series set", "err", err)
+				return false
+			}
+		}
+		return true
+	})
+	return querier, err
+}
+
+// extractFuncFromPath walks up the path and searches for the first instance of
+// a function or aggregation.
+func extractFuncFromPath(p []Node) string {
+	if len(p) == 0 {
+		return ""
+	}
+	switch n := p[len(p)-1].(type) {
+	case *AggregateExpr:
+		return n.Op.String()
+	case *Call:
+		return n.Func.Name
+	case *BinaryExpr:
+		// If we hit a binary expression we terminate since we only care about functions
+		// or aggregations over a single metric.
+		return ""
+	}
+	return extractFuncFromPath(p[:len(p)-1])
+}
+
+func expandSeriesSet(it storage.SeriesSet) (res []storage.Series, err error) {
+	for it.Next() {
+		res = append(res, it.At())
+	}
+	return res, it.Err()
+}
+
+// An evaluator evaluates given expressions over given fixed timestamps. It
+// is attached to an engine through which it connects to a querier and reports
+// errors. On timeout or cancellation of its context it terminates.
+type evaluator struct {
+	ctx context.Context
+
+	startTimestamp int64 // Start time in milliseconds.
+
+	endTimestamp int64 // End time in milliseconds.
+	interval     int64 // Interval in milliseconds.
+
+	logger log.Logger
+}
+
+// errorf causes a panic with the input formatted into an error.
+func (ev *evaluator) errorf(format string, args ...interface{}) {
+	ev.error(fmt.Errorf(format, args...))
+}
+
+// error causes a panic with the given error.
+func (ev *evaluator) error(err error) {
+	panic(err)
+}
+
+// recover is the handler that turns panics into returns from the top level of evaluation.
+func (ev *evaluator) recover(errp *error) {
+	e := recover()
+	if e == nil {
+		return
+	}
+	if err, ok := e.(runtime.Error); ok {
+		// Print the stack trace but do not inhibit the running application.
+		buf := make([]byte, 64<<10)
+		buf = buf[:runtime.Stack(buf, false)]
+
+		level.Error(ev.logger).Log("msg", "runtime panic in parser", "err", e, "stacktrace", string(buf))
+		*errp = fmt.Errorf("unexpected error: %s", err)
+	} else {
+		*errp = e.(error)
+	}
+}
+
+func (ev *evaluator) Eval(expr Expr) (v Value, err error) {
+	defer ev.recover(&err)
+	return ev.eval(expr), nil
+}
+
+// Extra information and caches for evaluating a single node across steps.
+type EvalNodeHelper struct {
+	// Evaluation timestamp.
+	ts int64
+	// Vector that can be used for output.
+	out Vector
+
+	// Caches.
+	// dropMetricName and label_*.
+	dmn map[uint64]labels.Labels
+	// signatureFunc.
+	sigf map[uint64]uint64
+	// funcHistogramQuantile.
+	signatureToMetricWithBuckets map[uint64]*metricWithBuckets
+	// label_replace.
+	regex *regexp.Regexp
+
+	// For binary vector matching.
+	rightSigs    map[uint64]Sample
+	matchedSigs  map[uint64]map[uint64]struct{}
+	resultMetric map[uint64]labels.Labels
+}
+
+// dropMetricName is a cached version of dropMetricName.
+func (enh *EvalNodeHelper) dropMetricName(l labels.Labels) labels.Labels {
+	if enh.dmn == nil {
+		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
+	}
+	h := l.Hash()
+	ret, ok := enh.dmn[h]
+	if ok {
+		return ret
+	}
+	ret = dropMetricName(l)
+	enh.dmn[h] = ret
+	return ret
+}
+
+// signatureFunc is a cached version of signatureFunc.
+func (enh *EvalNodeHelper) signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
+	if enh.sigf == nil {
+		enh.sigf = make(map[uint64]uint64, len(enh.out))
+	}
+	f := signatureFunc(on, names...)
+	return func(l labels.Labels) uint64 {
+		h := l.Hash()
+		ret, ok := enh.sigf[h]
+		if ok {
+			return ret
+		}
+		ret = f(l)
+		enh.sigf[h] = ret
+		return ret
+	}
+}
+
+// rangeEval evaluates the given expressions, and then for each step calls
+// the given function with the values computed for each expression at that
+// step.  The return value is the combination into time series of  of all the
+// function call results.
+func (ev *evaluator) rangeEval(f func([]Value, *EvalNodeHelper) Vector, exprs ...Expr) Matrix {
+	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+	matrixes := make([]Matrix, len(exprs))
+	origMatrixes := make([]Matrix, len(exprs))
+	for i, e := range exprs {
+		// Functions will take string arguments from the expressions, not the values.
+		if e != nil && e.Type() != ValueTypeString {
+			matrixes[i] = ev.eval(e).(Matrix)
+
+			// Keep a copy of the original point slices so that they
+			// can be returned to the pool.
+			origMatrixes[i] = make(Matrix, len(matrixes[i]))
+			copy(origMatrixes[i], matrixes[i])
+		}
+	}
+
+	vectors := make([]Vector, len(exprs)) // Input vectors for the function.
+	args := make([]Value, len(exprs))     // Argument to function.
+	// Create an output vector that is as big as the input matrix with
+	// the most time series.
+	biggestLen := 1
+	for i := range exprs {
+		vectors[i] = make(Vector, 0, len(matrixes[i]))
+		if len(matrixes[i]) > biggestLen {
+			biggestLen = len(matrixes[i])
+		}
+	}
+	enh := &EvalNodeHelper{out: make(Vector, 0, biggestLen)}
+	seriess := make(map[uint64]Series, biggestLen) // Output series by series hash.
+	for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+		// Gather input vectors for this timestamp.
+		for i := range exprs {
+			vectors[i] = vectors[i][:0]
+			for si, series := range matrixes[i] {
+				for _, point := range series.Points {
+					if point.T == ts {
+						vectors[i] = append(vectors[i], Sample{Metric: series.Metric, Point: point})
+						// Move input vectors forward so we don't have to re-scan the same
+						// past points at the next step.
+						matrixes[i][si].Points = series.Points[1:]
+					}
+					break
+				}
+			}
+			args[i] = vectors[i]
+		}
+		// Make the function call.
+		enh.ts = ts
+		result := f(args, enh)
+		enh.out = result[:0] // Reuse result vector.
+		// If this could be an instant query, shortcut so as not to change sort order.
+		if ev.endTimestamp == ev.startTimestamp {
+			mat := make(Matrix, len(result))
+			for i, s := range result {
+				s.Point.T = ts
+				mat[i] = Series{Metric: s.Metric, Points: []Point{s.Point}}
+			}
+			return mat
+		}
+		// Add samples in output vector to output series.
+		for _, sample := range result {
+			h := sample.Metric.Hash()
+			ss, ok := seriess[h]
+			if !ok {
+				ss = Series{
+					Metric: sample.Metric,
+					Points: getPointSlice(numSteps),
+				}
+			}
+			sample.Point.T = ts
+			ss.Points = append(ss.Points, sample.Point)
+			seriess[h] = ss
+		}
+	}
+	// Reuse the original point slices.
+	for _, m := range origMatrixes {
+		for _, s := range m {
+			putPointSlice(s.Points)
+		}
+	}
+	// Assemble the output matrix.
+	mat := make(Matrix, 0, len(seriess))
+	for _, ss := range seriess {
+		mat = append(mat, ss)
+	}
+	return mat
+}
+
+// eval evaluates the given expression as the given AST expression node requires.
+func (ev *evaluator) eval(expr Expr) Value {
+	// This is the top-level evaluation method.
+	// Thus, we check for timeout/cancellation here.
+	if err := contextDone(ev.ctx, "expression evaluation"); err != nil {
+		ev.error(err)
+	}
+	numSteps := int((ev.endTimestamp-ev.startTimestamp)/ev.interval) + 1
+
+	switch e := expr.(type) {
+	case *AggregateExpr:
+		if s, ok := e.Param.(*StringLiteral); ok {
+			return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+				return ev.aggregation(e.Op, e.Grouping, e.Without, s.Val, v[0].(Vector), enh)
+			}, e.Expr)
+		}
+		return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+			var param float64
+			if e.Param != nil {
+				param = v[0].(Vector)[0].V
+			}
+			return ev.aggregation(e.Op, e.Grouping, e.Without, param, v[1].(Vector), enh)
+		}, e.Param, e.Expr)
+
+	case *Call:
+		if e.Func.Name == "timestamp" {
+			// Matrix evaluation always returns the evaluation time,
+			// so this function needs special handling when given
+			// a vector selector.
+			vs, ok := e.Args[0].(*VectorSelector)
+			if ok {
+				return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+					return e.Func.Call([]Value{ev.vectorSelector(vs, enh.ts)}, e.Args, enh)
+				})
+			}
+		}
+		// Check if the function has a matrix argument.
+		var matrixArgIndex int
+		var matrixArg bool
+		for i, a := range e.Args {
+			_, ok := a.(*MatrixSelector)
+			if ok {
+				matrixArgIndex = i
+				matrixArg = true
+				break
+			}
+		}
+		if !matrixArg {
+			// Does not have a matrix argument.
+			return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+				return e.Func.Call(v, e.Args, enh)
+			}, e.Args...)
+		}
+
+		inArgs := make([]Value, len(e.Args))
+		// Evaluate any non-matrix arguments.
+		otherArgs := make([]Matrix, len(e.Args))
+		otherInArgs := make([]Vector, len(e.Args))
+		for i, e := range e.Args {
+			if i != matrixArgIndex {
+				otherArgs[i] = ev.eval(e).(Matrix)
+				otherInArgs[i] = Vector{Sample{}}
+				inArgs[i] = otherInArgs[i]
+			}
+		}
+
+		sel := e.Args[matrixArgIndex].(*MatrixSelector)
+		mat := make(Matrix, 0, len(sel.series)) // Output matrix.
+		offset := durationMilliseconds(sel.Offset)
+		selRange := durationMilliseconds(sel.Range)
+		// Reuse objects across steps to save memory allocations.
+		points := getPointSlice(16)
+		inMatrix := make(Matrix, 1)
+		inArgs[matrixArgIndex] = inMatrix
+		enh := &EvalNodeHelper{out: make(Vector, 0, 1)}
+		// Process all the calls for one time series at a time.
+		var it *storage.BufferedSeriesIterator
+		for i, s := range sel.series {
+			if it == nil {
+				it = storage.NewBuffer(s.Iterator(), selRange)
+			} else {
+				it.Reset(s.Iterator())
+			}
+			ss := Series{
+				// For all range vector functions, the only change to the
+				// output labels is dropping the metric name so just do
+				// it once here.
+				Metric: dropMetricName(sel.series[i].Labels()),
+				Points: getPointSlice(numSteps),
+			}
+			inMatrix[0].Metric = sel.series[i].Labels()
+			for ts, step := ev.startTimestamp, -1; ts <= ev.endTimestamp; ts += ev.interval {
+				step++
+				// Set the non-matrix arguments.
+				// They are scalar, so it is safe to use the step number
+				// when looking up the argument, as there will be no gaps.
+				for j := range e.Args {
+					if j != matrixArgIndex {
+						otherInArgs[j][0].V = otherArgs[j][0].Points[step].V
+					}
+				}
+				maxt := ts - offset
+				mint := maxt - selRange
+				// Evaluate the matrix selector for this series for this step.
+				points = ev.matrixIterSlice(it, mint, maxt, points[:0])
+				if len(points) == 0 {
+					continue
+				}
+				inMatrix[0].Points = points
+				enh.ts = ts
+				// Make the function call.
+				outVec := e.Func.Call(inArgs, e.Args, enh)
+				enh.out = outVec[:0]
+				if len(outVec) > 0 {
+					ss.Points = append(ss.Points, Point{V: outVec[0].Point.V, T: ts})
+				}
+			}
+			if len(ss.Points) > 0 {
+				mat = append(mat, ss)
+			}
+		}
+		putPointSlice(points)
+		return mat
+
+	case *ParenExpr:
+		return ev.eval(e.Expr)
+
+	case *UnaryExpr:
+		mat := ev.eval(e.Expr).(Matrix)
+		if e.Op == itemSUB {
+			for i := range mat {
+				mat[i].Metric = dropMetricName(mat[i].Metric)
+				for j := range mat[i].Points {
+					mat[i].Points[j].V = -mat[i].Points[j].V
+				}
+			}
+		}
+		return mat
+
+	case *BinaryExpr:
+		switch lt, rt := e.LHS.Type(), e.RHS.Type(); {
+		case lt == ValueTypeScalar && rt == ValueTypeScalar:
+			return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+				val := scalarBinop(e.Op, v[0].(Vector)[0].Point.V, v[1].(Vector)[0].Point.V)
+				return append(enh.out, Sample{Point: Point{V: val}})
+			}, e.LHS, e.RHS)
+		case lt == ValueTypeVector && rt == ValueTypeVector:
+			switch e.Op {
+			case itemLAND:
+				return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorAnd(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh)
+				}, e.LHS, e.RHS)
+			case itemLOR:
+				return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorOr(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh)
+				}, e.LHS, e.RHS)
+			case itemLUnless:
+				return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorUnless(v[0].(Vector), v[1].(Vector), e.VectorMatching, enh)
+				}, e.LHS, e.RHS)
+			default:
+				return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+					return ev.VectorBinop(e.Op, v[0].(Vector), v[1].(Vector), e.VectorMatching, e.ReturnBool, enh)
+				}, e.LHS, e.RHS)
+			}
+
+		case lt == ValueTypeVector && rt == ValueTypeScalar:
+			return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+				return ev.VectorscalarBinop(e.Op, v[0].(Vector), Scalar{V: v[1].(Vector)[0].Point.V}, false, e.ReturnBool, enh)
+			}, e.LHS, e.RHS)
+
+		case lt == ValueTypeScalar && rt == ValueTypeVector:
+			return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+				return ev.VectorscalarBinop(e.Op, v[1].(Vector), Scalar{V: v[0].(Vector)[0].Point.V}, true, e.ReturnBool, enh)
+			}, e.LHS, e.RHS)
+		}
+
+	case *NumberLiteral:
+		return ev.rangeEval(func(v []Value, enh *EvalNodeHelper) Vector {
+			return append(enh.out, Sample{Point: Point{V: e.Val}})
+		})
+
+	case *VectorSelector:
+		mat := make(Matrix, 0, len(e.series))
+		var it *storage.BufferedSeriesIterator
+		for i, s := range e.series {
+			if it == nil {
+				it = storage.NewBuffer(s.Iterator(), durationMilliseconds(LookbackDelta))
+			} else {
+				it.Reset(s.Iterator())
+			}
+			ss := Series{
+				Metric: e.series[i].Labels(),
+				Points: getPointSlice(numSteps),
+			}
+
+			for ts := ev.startTimestamp; ts <= ev.endTimestamp; ts += ev.interval {
+				_, v, ok := ev.vectorSelectorSingle(it, e, ts)
+				if ok {
+					ss.Points = append(ss.Points, Point{V: v, T: ts})
+				}
+			}
+
+			if len(ss.Points) > 0 {
+				mat = append(mat, ss)
+			}
+		}
+		return mat
+
+	case *MatrixSelector:
+		if ev.startTimestamp != ev.endTimestamp {
+			panic(fmt.Errorf("cannot do range evaluation of matrix selector"))
+		}
+		return ev.matrixSelector(e)
+	}
+
+	panic(fmt.Errorf("unhandled expression of type: %T", expr))
+}
+
+// vectorSelector evaluates a *VectorSelector expression.
+func (ev *evaluator) vectorSelector(node *VectorSelector, ts int64) Vector {
+	var (
+		vec = make(Vector, 0, len(node.series))
+	)
+
+	var it *storage.BufferedSeriesIterator
+	for i, s := range node.series {
+		if it == nil {
+			it = storage.NewBuffer(s.Iterator(), durationMilliseconds(LookbackDelta))
+		} else {
+			it.Reset(s.Iterator())
+		}
+
+		t, v, ok := ev.vectorSelectorSingle(it, node, ts)
+		if ok {
+			vec = append(vec, Sample{
+				Metric: node.series[i].Labels(),
+				Point:  Point{V: v, T: t},
+			})
+		}
+
+	}
+	return vec
+}
+
+// vectorSelectorSingle evaluates a instant vector for the iterator of one time series.
+func (ev *evaluator) vectorSelectorSingle(it *storage.BufferedSeriesIterator, node *VectorSelector, ts int64) (int64, float64, bool) {
+	refTime := ts - durationMilliseconds(node.Offset)
+	var t int64
+	var v float64
+
+	ok := it.Seek(refTime)
+	if !ok {
+		if it.Err() != nil {
+			ev.error(it.Err())
+		}
+	}
+
+	if ok {
+		t, v = it.Values()
+	}
+
+	if !ok || t > refTime {
+		t, v, ok = it.PeekBack(1)
+		if !ok || t < refTime-durationMilliseconds(LookbackDelta) {
+			return 0, 0, false
+		}
+	}
+	if value.IsStaleNaN(v) {
+		return 0, 0, false
+	}
+	return t, v, true
+}
+
+var pointPool = sync.Pool{}
+
+func getPointSlice(sz int) []Point {
+	p := pointPool.Get()
+	if p != nil {
+		return p.([]Point)
+	}
+	return make([]Point, 0, sz)
+}
+
+func putPointSlice(p []Point) {
+	pointPool.Put(p[:0])
+}
+
+// matrixSelector evaluates a *MatrixSelector expression.
+func (ev *evaluator) matrixSelector(node *MatrixSelector) Matrix {
+	var (
+		offset = durationMilliseconds(node.Offset)
+		maxt   = ev.startTimestamp - offset
+		mint   = maxt - durationMilliseconds(node.Range)
+		matrix = make(Matrix, 0, len(node.series))
+	)
+
+	var it *storage.BufferedSeriesIterator
+	for i, s := range node.series {
+		if it == nil {
+			it = storage.NewBuffer(s.Iterator(), durationMilliseconds(node.Range))
+		} else {
+			it.Reset(s.Iterator())
+		}
+		ss := Series{
+			Metric: node.series[i].Labels(),
+		}
+
+		ss.Points = ev.matrixIterSlice(it, mint, maxt, getPointSlice(16))
+
+		if len(ss.Points) > 0 {
+			matrix = append(matrix, ss)
+		}
+	}
+	return matrix
+}
+
+// matrixIterSlice evaluates a matrix vector for the iterator of one time series.
+func (ev *evaluator) matrixIterSlice(it *storage.BufferedSeriesIterator, mint, maxt int64, out []Point) []Point {
+	ok := it.Seek(maxt)
+	if !ok {
+		if it.Err() != nil {
+			ev.error(it.Err())
+		}
+	}
+
+	buf := it.Buffer()
+	for buf.Next() {
+		t, v := buf.At()
+		if value.IsStaleNaN(v) {
+			continue
+		}
+		// Values in the buffer are guaranteed to be smaller than maxt.
+		if t >= mint {
+			out = append(out, Point{T: t, V: v})
+		}
+	}
+	// The seeked sample might also be in the range.
+	if ok {
+		t, v := it.Values()
+		if t == maxt && !value.IsStaleNaN(v) {
+			out = append(out, Point{T: t, V: v})
+		}
+	}
+	return out
+}
+
+func (ev *evaluator) VectorAnd(lhs, rhs Vector, matching *VectorMatching, enh *EvalNodeHelper) Vector {
+	if matching.Card != CardManyToMany {
+		panic("set operations must only use many-to-many matching")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	// The set of signatures for the right-hand side Vector.
+	rightSigs := map[uint64]struct{}{}
+	// Add all rhs samples to a map so we can easily find matches later.
+	for _, rs := range rhs {
+		rightSigs[sigf(rs.Metric)] = struct{}{}
+	}
+
+	for _, ls := range lhs {
+		// If there's a matching entry in the right-hand side Vector, add the sample.
+		if _, ok := rightSigs[sigf(ls.Metric)]; ok {
+			enh.out = append(enh.out, ls)
+		}
+	}
+	return enh.out
+}
+
+func (ev *evaluator) VectorOr(lhs, rhs Vector, matching *VectorMatching, enh *EvalNodeHelper) Vector {
+	if matching.Card != CardManyToMany {
+		panic("set operations must only use many-to-many matching")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	leftSigs := map[uint64]struct{}{}
+	// Add everything from the left-hand-side Vector.
+	for _, ls := range lhs {
+		leftSigs[sigf(ls.Metric)] = struct{}{}
+		enh.out = append(enh.out, ls)
+	}
+	// Add all right-hand side elements which have not been added from the left-hand side.
+	for _, rs := range rhs {
+		if _, ok := leftSigs[sigf(rs.Metric)]; !ok {
+			enh.out = append(enh.out, rs)
+		}
+	}
+	return enh.out
+}
+
+func (ev *evaluator) VectorUnless(lhs, rhs Vector, matching *VectorMatching, enh *EvalNodeHelper) Vector {
+	if matching.Card != CardManyToMany {
+		panic("set operations must only use many-to-many matching")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	rightSigs := map[uint64]struct{}{}
+	for _, rs := range rhs {
+		rightSigs[sigf(rs.Metric)] = struct{}{}
+	}
+
+	for _, ls := range lhs {
+		if _, ok := rightSigs[sigf(ls.Metric)]; !ok {
+			enh.out = append(enh.out, ls)
+		}
+	}
+	return enh.out
+}
+
+// VectorBinop evaluates a binary operation between two Vectors, excluding set operators.
+func (ev *evaluator) VectorBinop(op ItemType, lhs, rhs Vector, matching *VectorMatching, returnBool bool, enh *EvalNodeHelper) Vector {
+	if matching.Card == CardManyToMany {
+		panic("many-to-many only allowed for set operators")
+	}
+	sigf := enh.signatureFunc(matching.On, matching.MatchingLabels...)
+
+	// The control flow below handles one-to-one or many-to-one matching.
+	// For one-to-many, swap sidedness and account for the swap when calculating
+	// values.
+	if matching.Card == CardOneToMany {
+		lhs, rhs = rhs, lhs
+	}
+
+	// All samples from the rhs hashed by the matching label/values.
+	if enh.rightSigs == nil {
+		enh.rightSigs = make(map[uint64]Sample, len(enh.out))
+	} else {
+		for k := range enh.rightSigs {
+			delete(enh.rightSigs, k)
+		}
+	}
+	rightSigs := enh.rightSigs
+
+	// Add all rhs samples to a map so we can easily find matches later.
+	for _, rs := range rhs {
+		sig := sigf(rs.Metric)
+		// The rhs is guaranteed to be the 'one' side. Having multiple samples
+		// with the same signature means that the matching is many-to-many.
+		if _, found := rightSigs[sig]; found {
+			// Many-to-many matching not allowed.
+			ev.errorf("many-to-many matching not allowed: matching labels must be unique on one side")
+		}
+		rightSigs[sig] = rs
+	}
+
+	// Tracks the match-signature. For one-to-one operations the value is nil. For many-to-one
+	// the value is a set of signatures to detect duplicated result elements.
+	if enh.matchedSigs == nil {
+		enh.matchedSigs = make(map[uint64]map[uint64]struct{}, len(rightSigs))
+	} else {
+		for k := range enh.matchedSigs {
+			delete(enh.matchedSigs, k)
+		}
+	}
+	matchedSigs := enh.matchedSigs
+
+	// For all lhs samples find a respective rhs sample and perform
+	// the binary operation.
+	for _, ls := range lhs {
+		sig := sigf(ls.Metric)
+
+		rs, found := rightSigs[sig] // Look for a match in the rhs Vector.
+		if !found {
+			continue
+		}
+
+		// Account for potentially swapped sidedness.
+		vl, vr := ls.V, rs.V
+		if matching.Card == CardOneToMany {
+			vl, vr = vr, vl
+		}
+		value, keep := vectorElemBinop(op, vl, vr)
+		if returnBool {
+			if keep {
+				value = 1.0
+			} else {
+				value = 0.0
+			}
+		} else if !keep {
+			continue
+		}
+		metric := resultMetric(ls.Metric, rs.Metric, op, matching, enh)
+
+		insertedSigs, exists := matchedSigs[sig]
+		if matching.Card == CardOneToOne {
+			if exists {
+				ev.errorf("multiple matches for labels: many-to-one matching must be explicit (group_left/group_right)")
+			}
+			matchedSigs[sig] = nil // Set existence to true.
+		} else {
+			// In many-to-one matching the grouping labels have to ensure a unique metric
+			// for the result Vector. Check whether those labels have already been added for
+			// the same matching labels.
+			insertSig := metric.Hash()
+
+			if !exists {
+				insertedSigs = map[uint64]struct{}{}
+				matchedSigs[sig] = insertedSigs
+			} else if _, duplicate := insertedSigs[insertSig]; duplicate {
+				ev.errorf("multiple matches for labels: grouping labels must ensure unique matches")
+			}
+			insertedSigs[insertSig] = struct{}{}
+		}
+
+		enh.out = append(enh.out, Sample{
+			Metric: metric,
+			Point:  Point{V: value},
+		})
+	}
+	return enh.out
+}
+
+func hashWithoutLabels(lset labels.Labels, names ...string) uint64 {
+	cm := make(labels.Labels, 0, len(lset))
+
+Outer:
+	for _, l := range lset {
+		for _, n := range names {
+			if n == l.Name {
+				continue Outer
+			}
+		}
+		if l.Name == labels.MetricName {
+			continue
+		}
+		cm = append(cm, l)
+	}
+
+	return cm.Hash()
+}
+
+func hashForLabels(lset labels.Labels, names ...string) uint64 {
+	cm := make(labels.Labels, 0, len(names))
+
+	for _, l := range lset {
+		for _, n := range names {
+			if l.Name == n {
+				cm = append(cm, l)
+				break
+			}
+		}
+	}
+	return cm.Hash()
+}
+
+// signatureFunc returns a function that calculates the signature for a metric
+// ignoring the provided labels. If on, then the given labels are only used instead.
+func signatureFunc(on bool, names ...string) func(labels.Labels) uint64 {
+	// TODO(fabxc): ensure names are sorted and then use that and sortedness
+	// of labels by names to speed up the operations below.
+	// Alternatively, inline the hashing and don't build new label sets.
+	if on {
+		return func(lset labels.Labels) uint64 { return hashForLabels(lset, names...) }
+	}
+	return func(lset labels.Labels) uint64 { return hashWithoutLabels(lset, names...) }
+}
+
+// resultMetric returns the metric for the given sample(s) based on the Vector
+// binary operation and the matching options.
+func resultMetric(lhs, rhs labels.Labels, op ItemType, matching *VectorMatching, enh *EvalNodeHelper) labels.Labels {
+	if enh.resultMetric == nil {
+		enh.resultMetric = make(map[uint64]labels.Labels, len(enh.out))
+	}
+	// op and matching are always the same for a given node, so
+	// there's no need to include them in the hash key.
+	// If the lhs and rhs are the same then the xor would be 0,
+	// so add in one side to protect against that.
+	lh := lhs.Hash()
+	h := (lh ^ rhs.Hash()) + lh
+	if ret, ok := enh.resultMetric[h]; ok {
+		return ret
+	}
+
+	lb := labels.NewBuilder(lhs)
+
+	if shouldDropMetricName(op) {
+		lb.Del(labels.MetricName)
+	}
+
+	if matching.Card == CardOneToOne {
+		if matching.On {
+		Outer:
+			for _, l := range lhs {
+				for _, n := range matching.MatchingLabels {
+					if l.Name == n {
+						continue Outer
+					}
+				}
+				lb.Del(l.Name)
+			}
+		} else {
+			lb.Del(matching.MatchingLabels...)
+		}
+	}
+	for _, ln := range matching.Include {
+		// Included labels from the `group_x` modifier are taken from the "one"-side.
+		if v := rhs.Get(ln); v != "" {
+			lb.Set(ln, v)
+		} else {
+			lb.Del(ln)
+		}
+	}
+
+	ret := lb.Labels()
+	enh.resultMetric[h] = ret
+	return ret
+}
+
+// VectorscalarBinop evaluates a binary operation between a Vector and a Scalar.
+func (ev *evaluator) VectorscalarBinop(op ItemType, lhs Vector, rhs Scalar, swap, returnBool bool, enh *EvalNodeHelper) Vector {
+	for _, lhsSample := range lhs {
+		lv, rv := lhsSample.V, rhs.V
+		// lhs always contains the Vector. If the original position was different
+		// swap for calculating the value.
+		if swap {
+			lv, rv = rv, lv
+		}
+		value, keep := vectorElemBinop(op, lv, rv)
+		if returnBool {
+			if keep {
+				value = 1.0
+			} else {
+				value = 0.0
+			}
+			keep = true
+		}
+		if keep {
+			lhsSample.V = value
+			if shouldDropMetricName(op) || returnBool {
+				lhsSample.Metric = enh.dropMetricName(lhsSample.Metric)
+			}
+			enh.out = append(enh.out, lhsSample)
+		}
+	}
+	return enh.out
+}
+
+func dropMetricName(l labels.Labels) labels.Labels {
+	return labels.NewBuilder(l).Del(labels.MetricName).Labels()
+}
+
+// scalarBinop evaluates a binary operation between two Scalars.
+func scalarBinop(op ItemType, lhs, rhs float64) float64 {
+	switch op {
+	case itemADD:
+		return lhs + rhs
+	case itemSUB:
+		return lhs - rhs
+	case itemMUL:
+		return lhs * rhs
+	case itemDIV:
+		return lhs / rhs
+	case itemPOW:
+		return math.Pow(float64(lhs), float64(rhs))
+	case itemMOD:
+		return math.Mod(float64(lhs), float64(rhs))
+	case itemEQL:
+		return btos(lhs == rhs)
+	case itemNEQ:
+		return btos(lhs != rhs)
+	case itemGTR:
+		return btos(lhs > rhs)
+	case itemLSS:
+		return btos(lhs < rhs)
+	case itemGTE:
+		return btos(lhs >= rhs)
+	case itemLTE:
+		return btos(lhs <= rhs)
+	}
+	panic(fmt.Errorf("operator %q not allowed for Scalar operations", op))
+}
+
+// vectorElemBinop evaluates a binary operation between two Vector elements.
+func vectorElemBinop(op ItemType, lhs, rhs float64) (float64, bool) {
+	switch op {
+	case itemADD:
+		return lhs + rhs, true
+	case itemSUB:
+		return lhs - rhs, true
+	case itemMUL:
+		return lhs * rhs, true
+	case itemDIV:
+		return lhs / rhs, true
+	case itemPOW:
+		return math.Pow(float64(lhs), float64(rhs)), true
+	case itemMOD:
+		return math.Mod(float64(lhs), float64(rhs)), true
+	case itemEQL:
+		return lhs, lhs == rhs
+	case itemNEQ:
+		return lhs, lhs != rhs
+	case itemGTR:
+		return lhs, lhs > rhs
+	case itemLSS:
+		return lhs, lhs < rhs
+	case itemGTE:
+		return lhs, lhs >= rhs
+	case itemLTE:
+		return lhs, lhs <= rhs
+	}
+	panic(fmt.Errorf("operator %q not allowed for operations between Vectors", op))
+}
+
+// intersection returns the metric of common label/value pairs of two input metrics.
+func intersection(ls1, ls2 labels.Labels) labels.Labels {
+	res := make(labels.Labels, 0, 5)
+
+	for _, l1 := range ls1 {
+		for _, l2 := range ls2 {
+			if l1.Name == l2.Name && l1.Value == l2.Value {
+				res = append(res, l1)
+				continue
+			}
+		}
+	}
+	return res
+}
+
+type groupedAggregation struct {
+	labels           labels.Labels
+	value            float64
+	valuesSquaredSum float64
+	groupCount       int
+	heap             vectorByValueHeap
+	reverseHeap      vectorByReverseValueHeap
+}
+
+// aggregation evaluates an aggregation operation on a Vector.
+func (ev *evaluator) aggregation(op ItemType, grouping []string, without bool, param interface{}, vec Vector, enh *EvalNodeHelper) Vector {
+
+	result := map[uint64]*groupedAggregation{}
+	var k int64
+	if op == itemTopK || op == itemBottomK {
+		f := param.(float64)
+		if !convertibleToInt64(f) {
+			ev.errorf("Scalar value %v overflows int64", f)
+		}
+		k = int64(f)
+		if k < 1 {
+			return Vector{}
+		}
+	}
+	var q float64
+	if op == itemQuantile {
+		q = param.(float64)
+	}
+	var valueLabel string
+	if op == itemCountValues {
+		valueLabel = param.(string)
+		if !without {
+			grouping = append(grouping, valueLabel)
+		}
+	}
+
+	for _, s := range vec {
+		lb := labels.NewBuilder(s.Metric)
+
+		if without {
+			lb.Del(grouping...)
+			lb.Del(labels.MetricName)
+		}
+		if op == itemCountValues {
+			lb.Set(valueLabel, strconv.FormatFloat(float64(s.V), 'f', -1, 64))
+		}
+
+		var (
+			groupingKey uint64
+			metric      = lb.Labels()
+		)
+		if without {
+			groupingKey = metric.Hash()
+		} else {
+			groupingKey = hashForLabels(metric, grouping...)
+		}
+
+		group, ok := result[groupingKey]
+		// Add a new group if it doesn't exist.
+		if !ok {
+			var m labels.Labels
+
+			if without {
+				m = metric
+			} else {
+				m = make(labels.Labels, 0, len(grouping))
+				for _, l := range metric {
+					for _, n := range grouping {
+						if l.Name == n {
+							m = append(m, labels.Label{Name: n, Value: l.Value})
+							break
+						}
+					}
+				}
+				sort.Sort(m)
+			}
+			result[groupingKey] = &groupedAggregation{
+				labels:           m,
+				value:            s.V,
+				valuesSquaredSum: s.V * s.V,
+				groupCount:       1,
+			}
+			input_vec_len := int64(len(vec))
+			result_size := k
+			if k > input_vec_len {
+				result_size = input_vec_len
+			}
+			if op == itemTopK || op == itemQuantile {
+				result[groupingKey].heap = make(vectorByValueHeap, 0, result_size)
+				heap.Push(&result[groupingKey].heap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			} else if op == itemBottomK {
+				result[groupingKey].reverseHeap = make(vectorByReverseValueHeap, 0, result_size)
+				heap.Push(&result[groupingKey].reverseHeap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			}
+			continue
+		}
+
+		switch op {
+		case itemSum:
+			group.value += s.V
+
+		case itemAvg:
+			group.value += s.V
+			group.groupCount++
+
+		case itemMax:
+			if group.value < s.V || math.IsNaN(float64(group.value)) {
+				group.value = s.V
+			}
+
+		case itemMin:
+			if group.value > s.V || math.IsNaN(float64(group.value)) {
+				group.value = s.V
+			}
+
+		case itemCount, itemCountValues:
+			group.groupCount++
+
+		case itemStdvar, itemStddev:
+			group.value += s.V
+			group.valuesSquaredSum += s.V * s.V
+			group.groupCount++
+
+		case itemTopK:
+			if int64(len(group.heap)) < k || group.heap[0].V < s.V || math.IsNaN(float64(group.heap[0].V)) {
+				if int64(len(group.heap)) == k {
+					heap.Pop(&group.heap)
+				}
+				heap.Push(&group.heap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			}
+
+		case itemBottomK:
+			if int64(len(group.reverseHeap)) < k || group.reverseHeap[0].V > s.V || math.IsNaN(float64(group.reverseHeap[0].V)) {
+				if int64(len(group.reverseHeap)) == k {
+					heap.Pop(&group.reverseHeap)
+				}
+				heap.Push(&group.reverseHeap, &Sample{
+					Point:  Point{V: s.V},
+					Metric: s.Metric,
+				})
+			}
+
+		case itemQuantile:
+			group.heap = append(group.heap, s)
+
+		default:
+			panic(fmt.Errorf("expected aggregation operator but got %q", op))
+		}
+	}
+
+	// Construct the result Vector from the aggregated groups.
+	for _, aggr := range result {
+		switch op {
+		case itemAvg:
+			aggr.value = aggr.value / float64(aggr.groupCount)
+
+		case itemCount, itemCountValues:
+			aggr.value = float64(aggr.groupCount)
+
+		case itemStdvar:
+			avg := float64(aggr.value) / float64(aggr.groupCount)
+			aggr.value = float64(aggr.valuesSquaredSum)/float64(aggr.groupCount) - avg*avg
+
+		case itemStddev:
+			avg := float64(aggr.value) / float64(aggr.groupCount)
+			aggr.value = math.Sqrt(float64(aggr.valuesSquaredSum)/float64(aggr.groupCount) - avg*avg)
+
+		case itemTopK:
+			// The heap keeps the lowest value on top, so reverse it.
+			sort.Sort(sort.Reverse(aggr.heap))
+			for _, v := range aggr.heap {
+				enh.out = append(enh.out, Sample{
+					Metric: v.Metric,
+					Point:  Point{V: v.V},
+				})
+			}
+			continue // Bypass default append.
+
+		case itemBottomK:
+			// The heap keeps the lowest value on top, so reverse it.
+			sort.Sort(sort.Reverse(aggr.reverseHeap))
+			for _, v := range aggr.reverseHeap {
+				enh.out = append(enh.out, Sample{
+					Metric: v.Metric,
+					Point:  Point{V: v.V},
+				})
+			}
+			continue // Bypass default append.
+
+		case itemQuantile:
+			aggr.value = quantile(q, aggr.heap)
+
+		default:
+			// For other aggregations, we already have the right value.
+		}
+
+		enh.out = append(enh.out, Sample{
+			Metric: aggr.labels,
+			Point:  Point{V: aggr.value},
+		})
+	}
+	return enh.out
+}
+
+// btos returns 1 if b is true, 0 otherwise.
+func btos(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// shouldDropMetricName returns whether the metric name should be dropped in the
+// result of the op operation.
+func shouldDropMetricName(op ItemType) bool {
+	switch op {
+	case itemADD, itemSUB, itemDIV, itemMUL, itemMOD:
+		return true
+	default:
+		return false
+	}
+}
+
+// LookbackDelta determines the time since the last sample after which a time
+// series is considered stale.
+var LookbackDelta = 5 * time.Minute
+
+// A queryGate controls the maximum number of concurrently running and waiting queries.
+type queryGate struct {
+	ch chan struct{}
+}
+
+// newQueryGate returns a query gate that limits the number of queries
+// being concurrently executed.
+func newQueryGate(length int) *queryGate {
+	return &queryGate{
+		ch: make(chan struct{}, length),
+	}
+}
+
+// Start blocks until the gate has a free spot or the context is done.
+func (g *queryGate) Start(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return contextDone(ctx, "query queue")
+	case g.ch <- struct{}{}:
+		return nil
+	}
+}
+
+// Done releases a single spot in the gate.
+func (g *queryGate) Done() {
+	select {
+	case <-g.ch:
+	default:
+		panic("engine.queryGate.Done: more operations done than started")
+	}
+}
+
+// documentedType returns the internal type to the equivalent
+// user facing terminology as defined in the documentation.
+func documentedType(t ValueType) string {
+	switch t {
+	case "vector":
+		return "instant vector"
+	case "matrix":
+		return "range vector"
+	default:
+		return string(t)
+	}
+}

--- a/vendor/github.com/prometheus/prometheus/promql/functions.go
+++ b/vendor/github.com/prometheus/prometheus/promql/functions.go
@@ -1,0 +1,1269 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// Function represents a function of the expression language and is
+// used by function nodes.
+type Function struct {
+	Name       string
+	ArgTypes   []ValueType
+	Variadic   int
+	ReturnType ValueType
+
+	// vals is a list of the evaluated arguments for the function call.
+	//    For range vectors it will be a Matrix with one series, instant vectors a
+	//    Vector, scalars a Vector with one series whose value is the scalar
+	//    value,and nil for strings.
+	// args are the original arguments to the function, where you can access
+	//    matrixSelectors, vectorSelectors, and StringLiterals.
+	// enh.out is a pre-allocated empty vector that you may use to accumulate
+	//    output before returning it. The vectors in vals should not be returned.a
+	// Range vector functions need only return a vector with the right value,
+	//     the metric and timestamp are not neded.
+	// Instant vector functions need only return a vector with the right values and
+	//     metrics, the timestamp are not needed.
+	// Scalar results should be returned as the value of a sample in a Vector.
+	Call func(vals []Value, args Expressions, enh *EvalNodeHelper) Vector
+}
+
+// === time() float64 ===
+func funcTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return Vector{Sample{Point: Point{
+		V: float64(enh.ts) / 1000,
+	}}}
+}
+
+// extrapolatedRate is a utility function for rate/increase/delta.
+// It calculates the rate (allowing for counter resets if isCounter is true),
+// extrapolates if the first/last sample is close to the boundary, and returns
+// the result as either per-second (if isRate is true) or overall.
+func extrapolatedRate(vals []Value, args Expressions, enh *EvalNodeHelper, isCounter bool, isRate bool) Vector {
+	ms := args[0].(*MatrixSelector)
+
+	var (
+		matrix     = vals[0].(Matrix)
+		rangeStart = enh.ts - durationMilliseconds(ms.Range+ms.Offset)
+		rangeEnd   = enh.ts - durationMilliseconds(ms.Offset)
+	)
+
+	for _, samples := range matrix {
+		// No sense in trying to compute a rate without at least two points. Drop
+		// this Vector element.
+		if len(samples.Points) < 2 {
+			continue
+		}
+		var (
+			counterCorrection float64
+			lastValue         float64
+		)
+		for _, sample := range samples.Points {
+			if isCounter && sample.V < lastValue {
+				counterCorrection += lastValue
+			}
+			lastValue = sample.V
+		}
+		resultValue := lastValue - samples.Points[0].V + counterCorrection
+
+		// Duration between first/last samples and boundary of range.
+		durationToStart := float64(samples.Points[0].T-rangeStart) / 1000
+		durationToEnd := float64(rangeEnd-samples.Points[len(samples.Points)-1].T) / 1000
+
+		sampledInterval := float64(samples.Points[len(samples.Points)-1].T-samples.Points[0].T) / 1000
+		averageDurationBetweenSamples := sampledInterval / float64(len(samples.Points)-1)
+
+		if isCounter && resultValue > 0 && samples.Points[0].V >= 0 {
+			// Counters cannot be negative. If we have any slope at
+			// all (i.e. resultValue went up), we can extrapolate
+			// the zero point of the counter. If the duration to the
+			// zero point is shorter than the durationToStart, we
+			// take the zero point as the start of the series,
+			// thereby avoiding extrapolation to negative counter
+			// values.
+			durationToZero := sampledInterval * (samples.Points[0].V / resultValue)
+			if durationToZero < durationToStart {
+				durationToStart = durationToZero
+			}
+		}
+
+		// If the first/last samples are close to the boundaries of the range,
+		// extrapolate the result. This is as we expect that another sample
+		// will exist given the spacing between samples we've seen thus far,
+		// with an allowance for noise.
+		extrapolationThreshold := averageDurationBetweenSamples * 1.1
+		extrapolateToInterval := sampledInterval
+
+		if durationToStart < extrapolationThreshold {
+			extrapolateToInterval += durationToStart
+		} else {
+			extrapolateToInterval += averageDurationBetweenSamples / 2
+		}
+		if durationToEnd < extrapolationThreshold {
+			extrapolateToInterval += durationToEnd
+		} else {
+			extrapolateToInterval += averageDurationBetweenSamples / 2
+		}
+		resultValue = resultValue * (extrapolateToInterval / sampledInterval)
+		if isRate {
+			resultValue = resultValue / ms.Range.Seconds()
+		}
+
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: resultValue},
+		})
+	}
+	return enh.out
+}
+
+// === delta(Matrix ValueTypeMatrix) Vector ===
+func funcDelta(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return extrapolatedRate(vals, args, enh, false, false)
+}
+
+// === rate(node ValueTypeMatrix) Vector ===
+func funcRate(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return extrapolatedRate(vals, args, enh, true, true)
+}
+
+// === increase(node ValueTypeMatrix) Vector ===
+func funcIncrease(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return extrapolatedRate(vals, args, enh, true, false)
+}
+
+// === irate(node ValueTypeMatrix) Vector ===
+func funcIrate(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return instantValue(vals, enh.out, true)
+}
+
+// === idelta(node model.ValMatric) Vector ===
+func funcIdelta(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return instantValue(vals, enh.out, false)
+}
+
+func instantValue(vals []Value, out Vector, isRate bool) Vector {
+	for _, samples := range vals[0].(Matrix) {
+		// No sense in trying to compute a rate without at least two points. Drop
+		// this Vector element.
+		if len(samples.Points) < 2 {
+			continue
+		}
+
+		lastSample := samples.Points[len(samples.Points)-1]
+		previousSample := samples.Points[len(samples.Points)-2]
+
+		var resultValue float64
+		if isRate && lastSample.V < previousSample.V {
+			// Counter reset.
+			resultValue = lastSample.V
+		} else {
+			resultValue = lastSample.V - previousSample.V
+		}
+
+		sampledInterval := lastSample.T - previousSample.T
+		if sampledInterval == 0 {
+			// Avoid dividing by 0.
+			continue
+		}
+
+		if isRate {
+			// Convert to per-second.
+			resultValue /= float64(sampledInterval) / 1000
+		}
+
+		out = append(out, Sample{
+			Point: Point{V: resultValue},
+		})
+	}
+	return out
+}
+
+// Calculate the trend value at the given index i in raw data d.
+// This is somewhat analogous to the slope of the trend at the given index.
+// The argument "s" is the set of computed smoothed values.
+// The argument "b" is the set of computed trend factors.
+// The argument "d" is the set of raw input values.
+func calcTrendValue(i int, sf, tf, s0, s1, b float64) float64 {
+	if i == 0 {
+		return b
+	}
+
+	x := tf * (s1 - s0)
+	y := (1 - tf) * b
+
+	return x + y
+}
+
+// Holt-Winters is similar to a weighted moving average, where historical data has exponentially less influence on the current data.
+// Holt-Winter also accounts for trends in data. The smoothing factor (0 < sf < 1) affects how historical data will affect the current
+// data. A lower smoothing factor increases the influence of historical data. The trend factor (0 < tf < 1) affects
+// how trends in historical data will affect the current data. A higher trend factor increases the influence.
+// of trends. Algorithm taken from https://en.wikipedia.org/wiki/Exponential_smoothing titled: "Double exponential smoothing".
+func funcHoltWinters(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	mat := vals[0].(Matrix)
+
+	// The smoothing factor argument.
+	sf := vals[1].(Vector)[0].V
+
+	// The trend factor argument.
+	tf := vals[2].(Vector)[0].V
+
+	// Sanity check the input.
+	if sf <= 0 || sf >= 1 {
+		panic(fmt.Errorf("invalid smoothing factor. Expected: 0 < sf < 1 goT: %f", sf))
+	}
+	if tf <= 0 || tf >= 1 {
+		panic(fmt.Errorf("invalid trend factor. Expected: 0 < tf < 1 goT: %f", sf))
+	}
+
+	var l int
+	for _, samples := range mat {
+		l = len(samples.Points)
+
+		// Can't do the smoothing operation with less than two points.
+		if l < 2 {
+			continue
+		}
+
+		var s0, s1, b float64
+		// Set initial values.
+		s1 = samples.Points[0].V
+		b = samples.Points[1].V - samples.Points[0].V
+
+		// Run the smoothing operation.
+		var x, y float64
+		for i := 1; i < l; i++ {
+
+			// Scale the raw value against the smoothing factor.
+			x = sf * samples.Points[i].V
+
+			// Scale the last smoothed value with the trend at this point.
+			b = calcTrendValue(i-1, sf, tf, s0, s1, b)
+			y = (1 - sf) * (s1 + b)
+
+			s0, s1 = s1, x+y
+		}
+
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: s1},
+		})
+	}
+
+	return enh.out
+}
+
+// === sort(node ValueTypeVector) Vector ===
+func funcSort(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	// NaN should sort to the bottom, so take descending sort with NaN first and
+	// reverse it.
+	byValueSorter := vectorByReverseValueHeap(vals[0].(Vector))
+	sort.Sort(sort.Reverse(byValueSorter))
+	return Vector(byValueSorter)
+}
+
+// === sortDesc(node ValueTypeVector) Vector ===
+func funcSortDesc(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	// NaN should sort to the bottom, so take ascending sort with NaN first and
+	// reverse it.
+	byValueSorter := vectorByValueHeap(vals[0].(Vector))
+	sort.Sort(sort.Reverse(byValueSorter))
+	return Vector(byValueSorter)
+}
+
+// === clamp_max(Vector ValueTypeVector, max Scalar) Vector ===
+func funcClampMax(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	max := vals[1].(Vector)[0].Point.V
+	for _, el := range vec {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: math.Min(max, float64(el.V))},
+		})
+	}
+	return enh.out
+}
+
+// === clamp_min(Vector ValueTypeVector, min Scalar) Vector ===
+func funcClampMin(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	min := vals[1].(Vector)[0].Point.V
+	for _, el := range vec {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: math.Max(min, float64(el.V))},
+		})
+	}
+	return enh.out
+}
+
+// === round(Vector ValueTypeVector, toNearest=1 Scalar) Vector ===
+func funcRound(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	// round returns a number rounded to toNearest.
+	// Ties are solved by rounding up.
+	toNearest := float64(1)
+	if len(args) >= 2 {
+		toNearest = vals[1].(Vector)[0].Point.V
+	}
+	// Invert as it seems to cause fewer floating point accuracy issues.
+	toNearestInverse := 1.0 / toNearest
+
+	for _, el := range vec {
+		v := math.Floor(float64(el.V)*toNearestInverse+0.5) / toNearestInverse
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: v},
+		})
+	}
+	return enh.out
+}
+
+// === Scalar(node ValueTypeVector) Scalar ===
+func funcScalar(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	v := vals[0].(Vector)
+	if len(v) != 1 {
+		return append(enh.out, Sample{
+			Point: Point{V: math.NaN()},
+		})
+	}
+	return append(enh.out, Sample{
+		Point: Point{V: v[0].V},
+	})
+}
+
+func aggrOverTime(vals []Value, enh *EvalNodeHelper, aggrFn func([]Point) float64) Vector {
+	mat := vals[0].(Matrix)
+
+	for _, el := range mat {
+		if len(el.Points) == 0 {
+			continue
+		}
+
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: aggrFn(el.Points)},
+		})
+	}
+	return enh.out
+}
+
+// === avg_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcAvgOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var sum float64
+		for _, v := range values {
+			sum += v.V
+		}
+		return sum / float64(len(values))
+	})
+}
+
+// === count_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcCountOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		return float64(len(values))
+	})
+}
+
+// === floor(Vector ValueTypeVector) Vector ===
+// === max_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcMaxOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		max := math.Inf(-1)
+		for _, v := range values {
+			max = math.Max(max, float64(v.V))
+		}
+		return max
+	})
+}
+
+// === min_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcMinOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		min := math.Inf(1)
+		for _, v := range values {
+			min = math.Min(min, float64(v.V))
+		}
+		return min
+	})
+}
+
+// === sum_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcSumOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var sum float64
+		for _, v := range values {
+			sum += v.V
+		}
+		return sum
+	})
+}
+
+// === quantile_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcQuantileOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	q := vals[0].(Vector)[0].V
+	mat := vals[1].(Matrix)
+
+	for _, el := range mat {
+		if len(el.Points) == 0 {
+			continue
+		}
+
+		values := make(vectorByValueHeap, 0, len(el.Points))
+		for _, v := range el.Points {
+			values = append(values, Sample{Point: Point{V: v.V}})
+		}
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: quantile(q, values)},
+		})
+	}
+	return enh.out
+}
+
+// === stddev_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcStddevOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var sum, squaredSum, count float64
+		for _, v := range values {
+			sum += v.V
+			squaredSum += v.V * v.V
+			count++
+		}
+		avg := sum / count
+		return math.Sqrt(float64(squaredSum/count - avg*avg))
+	})
+}
+
+// === stdvar_over_time(Matrix ValueTypeMatrix) Vector ===
+func funcStdvarOverTime(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return aggrOverTime(vals, enh, func(values []Point) float64 {
+		var sum, squaredSum, count float64
+		for _, v := range values {
+			sum += v.V
+			squaredSum += v.V * v.V
+			count++
+		}
+		avg := sum / count
+		return squaredSum/count - avg*avg
+	})
+}
+
+// === absent(Vector ValueTypeVector) Vector ===
+func funcAbsent(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	if len(vals[0].(Vector)) > 0 {
+		return enh.out
+	}
+	m := []labels.Label{}
+
+	if vs, ok := args[0].(*VectorSelector); ok {
+		for _, ma := range vs.LabelMatchers {
+			if ma.Type == labels.MatchEqual && ma.Name != labels.MetricName {
+				m = append(m, labels.Label{Name: ma.Name, Value: ma.Value})
+			}
+		}
+	}
+	return append(enh.out,
+		Sample{
+			Metric: labels.New(m...),
+			Point:  Point{V: 1},
+		})
+}
+
+func simpleFunc(vals []Value, enh *EvalNodeHelper, f func(float64) float64) Vector {
+	for _, el := range vals[0].(Vector) {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: f(el.V)},
+		})
+	}
+	return enh.out
+}
+
+// === abs(Vector ValueTypeVector) Vector ===
+func funcAbs(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Abs)
+}
+
+// === ceil(Vector ValueTypeVector) Vector ===
+func funcCeil(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Ceil)
+}
+
+// === floor(Vector ValueTypeVector) Vector ===
+func funcFloor(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Floor)
+}
+
+// === exp(Vector ValueTypeVector) Vector ===
+func funcExp(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Exp)
+}
+
+// === sqrt(Vector VectorNode) Vector ===
+func funcSqrt(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Sqrt)
+}
+
+// === ln(Vector ValueTypeVector) Vector ===
+func funcLn(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Log)
+}
+
+// === log2(Vector ValueTypeVector) Vector ===
+func funcLog2(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Log2)
+}
+
+// === log10(Vector ValueTypeVector) Vector ===
+func funcLog10(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return simpleFunc(vals, enh, math.Log10)
+}
+
+// === timestamp(Vector ValueTypeVector) Vector ===
+func funcTimestamp(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	vec := vals[0].(Vector)
+	for _, el := range vec {
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: float64(el.T) / 1000},
+		})
+	}
+	return enh.out
+}
+
+// linearRegression performs a least-square linear regression analysis on the
+// provided SamplePairs. It returns the slope, and the intercept value at the
+// provided time.
+func linearRegression(samples []Point, interceptTime int64) (slope, intercept float64) {
+	var (
+		n            float64
+		sumX, sumY   float64
+		sumXY, sumX2 float64
+	)
+	for _, sample := range samples {
+		x := float64(sample.T-interceptTime) / 1e3
+		n += 1.0
+		sumY += sample.V
+		sumX += x
+		sumXY += x * sample.V
+		sumX2 += x * x
+	}
+	covXY := sumXY - sumX*sumY/n
+	varX := sumX2 - sumX*sumX/n
+
+	slope = covXY / varX
+	intercept = sumY/n - slope*sumX/n
+	return slope, intercept
+}
+
+// === deriv(node ValueTypeMatrix) Vector ===
+func funcDeriv(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	mat := vals[0].(Matrix)
+
+	for _, samples := range mat {
+		// No sense in trying to compute a derivative without at least two points.
+		// Drop this Vector element.
+		if len(samples.Points) < 2 {
+			continue
+		}
+
+		// We pass in an arbitrary timestamp that is near the values in use
+		// to avoid floating point accuracy issues, see
+		// https://github.com/prometheus/prometheus/issues/2674
+		slope, _ := linearRegression(samples.Points, samples.Points[0].T)
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: slope},
+		})
+	}
+	return enh.out
+}
+
+// === predict_linear(node ValueTypeMatrix, k ValueTypeScalar) Vector ===
+func funcPredictLinear(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	mat := vals[0].(Matrix)
+	duration := vals[1].(Vector)[0].V
+
+	for _, samples := range mat {
+		// No sense in trying to predict anything without at least two points.
+		// Drop this Vector element.
+		if len(samples.Points) < 2 {
+			continue
+		}
+		slope, intercept := linearRegression(samples.Points, enh.ts)
+
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: slope*duration + intercept},
+		})
+	}
+	return enh.out
+}
+
+// === histogram_quantile(k ValueTypeScalar, Vector ValueTypeVector) Vector ===
+func funcHistogramQuantile(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	q := vals[0].(Vector)[0].V
+	inVec := vals[1].(Vector)
+	sigf := enh.signatureFunc(false, excludedLabels...)
+
+	if enh.signatureToMetricWithBuckets == nil {
+		enh.signatureToMetricWithBuckets = map[uint64]*metricWithBuckets{}
+	} else {
+		for _, v := range enh.signatureToMetricWithBuckets {
+			v.buckets = v.buckets[:0]
+		}
+	}
+	for _, el := range inVec {
+		upperBound, err := strconv.ParseFloat(
+			el.Metric.Get(model.BucketLabel), 64,
+		)
+		if err != nil {
+			// Oops, no bucket label or malformed label value. Skip.
+			// TODO(beorn7): Issue a warning somehow.
+			continue
+		}
+		hash := sigf(el.Metric)
+
+		mb, ok := enh.signatureToMetricWithBuckets[hash]
+		if !ok {
+			el.Metric = labels.NewBuilder(el.Metric).
+				Del(labels.BucketLabel, labels.MetricName).
+				Labels()
+
+			mb = &metricWithBuckets{el.Metric, nil}
+			enh.signatureToMetricWithBuckets[hash] = mb
+		}
+		mb.buckets = append(mb.buckets, bucket{upperBound, el.V})
+	}
+
+	for _, mb := range enh.signatureToMetricWithBuckets {
+		if len(mb.buckets) > 0 {
+			enh.out = append(enh.out, Sample{
+				Metric: mb.metric,
+				Point:  Point{V: bucketQuantile(q, mb.buckets)},
+			})
+		}
+	}
+
+	return enh.out
+}
+
+// === resets(Matrix ValueTypeMatrix) Vector ===
+func funcResets(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	in := vals[0].(Matrix)
+
+	for _, samples := range in {
+		resets := 0
+		prev := samples.Points[0].V
+		for _, sample := range samples.Points[1:] {
+			current := sample.V
+			if current < prev {
+				resets++
+			}
+			prev = current
+		}
+
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: float64(resets)},
+		})
+	}
+	return enh.out
+}
+
+// === changes(Matrix ValueTypeMatrix) Vector ===
+func funcChanges(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	in := vals[0].(Matrix)
+
+	for _, samples := range in {
+		changes := 0
+		prev := samples.Points[0].V
+		for _, sample := range samples.Points[1:] {
+			current := sample.V
+			if current != prev && !(math.IsNaN(float64(current)) && math.IsNaN(float64(prev))) {
+				changes++
+			}
+			prev = current
+		}
+
+		enh.out = append(enh.out, Sample{
+			Point: Point{V: float64(changes)},
+		})
+	}
+	return enh.out
+}
+
+// === label_replace(Vector ValueTypeVector, dst_label, replacement, src_labelname, regex ValueTypeString) Vector ===
+func funcLabelReplace(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	var (
+		vector   = vals[0].(Vector)
+		dst      = args[1].(*StringLiteral).Val
+		repl     = args[2].(*StringLiteral).Val
+		src      = args[3].(*StringLiteral).Val
+		regexStr = args[4].(*StringLiteral).Val
+	)
+
+	if enh.regex == nil {
+		var err error
+		enh.regex, err = regexp.Compile("^(?:" + regexStr + ")$")
+		if err != nil {
+			panic(fmt.Errorf("invalid regular expression in label_replace(): %s", regexStr))
+		}
+		if !model.LabelNameRE.MatchString(string(dst)) {
+			panic(fmt.Errorf("invalid destination label name in label_replace(): %s", dst))
+		}
+		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
+	}
+
+	outSet := make(map[uint64]struct{}, len(vector))
+	for _, el := range vector {
+		h := el.Metric.Hash()
+		var outMetric labels.Labels
+		if l, ok := enh.dmn[h]; ok {
+			outMetric = l
+		} else {
+			srcVal := el.Metric.Get(src)
+			indexes := enh.regex.FindStringSubmatchIndex(srcVal)
+			if indexes == nil {
+				// If there is no match, no replacement should take place.
+				outMetric = el.Metric
+				enh.dmn[h] = outMetric
+			} else {
+				res := enh.regex.ExpandString([]byte{}, repl, srcVal, indexes)
+
+				lb := labels.NewBuilder(el.Metric).Del(dst)
+				if len(res) > 0 {
+					lb.Set(dst, string(res))
+				}
+				outMetric = lb.Labels()
+				enh.dmn[h] = outMetric
+			}
+		}
+
+		outHash := outMetric.Hash()
+		if _, ok := outSet[outHash]; ok {
+			panic(fmt.Errorf("duplicated label set in output of label_replace(): %s", el.Metric))
+		} else {
+			enh.out = append(enh.out,
+				Sample{
+					Metric: outMetric,
+					Point:  Point{V: el.Point.V},
+				})
+			outSet[outHash] = struct{}{}
+		}
+	}
+	return enh.out
+}
+
+// === Vector(s Scalar) Vector ===
+func funcVector(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return append(enh.out,
+		Sample{
+			Metric: labels.Labels{},
+			Point:  Point{V: vals[0].(Vector)[0].V},
+		})
+}
+
+// === label_join(vector model.ValVector, dest_labelname, separator, src_labelname...) Vector ===
+func funcLabelJoin(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	var (
+		vector    = vals[0].(Vector)
+		dst       = args[1].(*StringLiteral).Val
+		sep       = args[2].(*StringLiteral).Val
+		srcLabels = make([]string, len(args)-3)
+	)
+
+	if enh.dmn == nil {
+		enh.dmn = make(map[uint64]labels.Labels, len(enh.out))
+	}
+
+	for i := 3; i < len(args); i++ {
+		src := args[i].(*StringLiteral).Val
+		if !model.LabelName(src).IsValid() {
+			panic(fmt.Errorf("invalid source label name in label_join(): %s", src))
+		}
+		srcLabels[i-3] = src
+	}
+
+	if !model.LabelName(dst).IsValid() {
+		panic(fmt.Errorf("invalid destination label name in label_join(): %s", dst))
+	}
+
+	outSet := make(map[uint64]struct{}, len(vector))
+	srcVals := make([]string, len(srcLabels))
+	for _, el := range vector {
+		h := el.Metric.Hash()
+		var outMetric labels.Labels
+		if l, ok := enh.dmn[h]; ok {
+			outMetric = l
+		} else {
+
+			for i, src := range srcLabels {
+				srcVals[i] = el.Metric.Get(src)
+			}
+
+			lb := labels.NewBuilder(el.Metric)
+
+			strval := strings.Join(srcVals, sep)
+			if strval == "" {
+				lb.Del(dst)
+			} else {
+				lb.Set(dst, strval)
+			}
+
+			outMetric = lb.Labels()
+			enh.dmn[h] = outMetric
+		}
+		outHash := outMetric.Hash()
+
+		if _, exists := outSet[outHash]; exists {
+			panic(fmt.Errorf("duplicated label set in output of label_join(): %s", el.Metric))
+		} else {
+			enh.out = append(enh.out, Sample{
+				Metric: outMetric,
+				Point:  Point{V: el.Point.V},
+			})
+			outSet[outHash] = struct{}{}
+		}
+	}
+	return enh.out
+}
+
+// Common code for date related functions.
+func dateWrapper(vals []Value, enh *EvalNodeHelper, f func(time.Time) float64) Vector {
+	if len(vals) == 0 {
+		return append(enh.out,
+			Sample{
+				Metric: labels.Labels{},
+				Point:  Point{V: f(time.Unix(enh.ts/1000, 0).UTC())},
+			})
+	}
+
+	for _, el := range vals[0].(Vector) {
+		t := time.Unix(int64(el.V), 0).UTC()
+		enh.out = append(enh.out, Sample{
+			Metric: enh.dropMetricName(el.Metric),
+			Point:  Point{V: f(t)},
+		})
+	}
+	return enh.out
+}
+
+// === days_in_month(v Vector) Scalar ===
+func funcDaysInMonth(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(32 - time.Date(t.Year(), t.Month(), 32, 0, 0, 0, 0, time.UTC).Day())
+	})
+}
+
+// === day_of_month(v Vector) Scalar ===
+func funcDayOfMonth(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Day())
+	})
+}
+
+// === day_of_week(v Vector) Scalar ===
+func funcDayOfWeek(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Weekday())
+	})
+}
+
+// === hour(v Vector) Scalar ===
+func funcHour(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Hour())
+	})
+}
+
+// === minute(v Vector) Scalar ===
+func funcMinute(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Minute())
+	})
+}
+
+// === month(v Vector) Scalar ===
+func funcMonth(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Month())
+	})
+}
+
+// === year(v Vector) Scalar ===
+func funcYear(vals []Value, args Expressions, enh *EvalNodeHelper) Vector {
+	return dateWrapper(vals, enh, func(t time.Time) float64 {
+		return float64(t.Year())
+	})
+}
+
+var functions = map[string]*Function{
+	"abs": {
+		Name:       "abs",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcAbs,
+	},
+	"absent": {
+		Name:       "absent",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcAbsent,
+	},
+	"avg_over_time": {
+		Name:       "avg_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcAvgOverTime,
+	},
+	"ceil": {
+		Name:       "ceil",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcCeil,
+	},
+	"changes": {
+		Name:       "changes",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcChanges,
+	},
+	"clamp_max": {
+		Name:       "clamp_max",
+		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+		Call:       funcClampMax,
+	},
+	"clamp_min": {
+		Name:       "clamp_min",
+		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+		Call:       funcClampMin,
+	},
+	"count_over_time": {
+		Name:       "count_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcCountOverTime,
+	},
+	"days_in_month": {
+		Name:       "days_in_month",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcDaysInMonth,
+	},
+	"day_of_month": {
+		Name:       "day_of_month",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcDayOfMonth,
+	},
+	"day_of_week": {
+		Name:       "day_of_week",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcDayOfWeek,
+	},
+	"delta": {
+		Name:       "delta",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcDelta,
+	},
+	"deriv": {
+		Name:       "deriv",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcDeriv,
+	},
+	"exp": {
+		Name:       "exp",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcExp,
+	},
+	"floor": {
+		Name:       "floor",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcFloor,
+	},
+	"histogram_quantile": {
+		Name:       "histogram_quantile",
+		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcHistogramQuantile,
+	},
+	"holt_winters": {
+		Name:       "holt_winters",
+		ArgTypes:   []ValueType{ValueTypeMatrix, ValueTypeScalar, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+		Call:       funcHoltWinters,
+	},
+	"hour": {
+		Name:       "hour",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcHour,
+	},
+	"idelta": {
+		Name:       "idelta",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcIdelta,
+	},
+	"increase": {
+		Name:       "increase",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcIncrease,
+	},
+	"irate": {
+		Name:       "irate",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcIrate,
+	},
+	"label_replace": {
+		Name:       "label_replace",
+		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeString, ValueTypeString, ValueTypeString, ValueTypeString},
+		ReturnType: ValueTypeVector,
+		Call:       funcLabelReplace,
+	},
+	"label_join": {
+		Name:       "label_join",
+		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeString, ValueTypeString, ValueTypeString},
+		Variadic:   -1,
+		ReturnType: ValueTypeVector,
+		Call:       funcLabelJoin,
+	},
+	"ln": {
+		Name:       "ln",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcLn,
+	},
+	"log10": {
+		Name:       "log10",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcLog10,
+	},
+	"log2": {
+		Name:       "log2",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcLog2,
+	},
+	"max_over_time": {
+		Name:       "max_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcMaxOverTime,
+	},
+	"min_over_time": {
+		Name:       "min_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcMinOverTime,
+	},
+	"minute": {
+		Name:       "minute",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcMinute,
+	},
+	"month": {
+		Name:       "month",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcMonth,
+	},
+	"predict_linear": {
+		Name:       "predict_linear",
+		ArgTypes:   []ValueType{ValueTypeMatrix, ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+		Call:       funcPredictLinear,
+	},
+	"quantile_over_time": {
+		Name:       "quantile_over_time",
+		ArgTypes:   []ValueType{ValueTypeScalar, ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcQuantileOverTime,
+	},
+	"rate": {
+		Name:       "rate",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcRate,
+	},
+	"resets": {
+		Name:       "resets",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcResets,
+	},
+	"round": {
+		Name:       "round",
+		ArgTypes:   []ValueType{ValueTypeVector, ValueTypeScalar},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcRound,
+	},
+	"scalar": {
+		Name:       "scalar",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeScalar,
+		Call:       funcScalar,
+	},
+	"sort": {
+		Name:       "sort",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcSort,
+	},
+	"sort_desc": {
+		Name:       "sort_desc",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcSortDesc,
+	},
+	"sqrt": {
+		Name:       "sqrt",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcSqrt,
+	},
+	"stddev_over_time": {
+		Name:       "stddev_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcStddevOverTime,
+	},
+	"stdvar_over_time": {
+		Name:       "stdvar_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcStdvarOverTime,
+	},
+	"sum_over_time": {
+		Name:       "sum_over_time",
+		ArgTypes:   []ValueType{ValueTypeMatrix},
+		ReturnType: ValueTypeVector,
+		Call:       funcSumOverTime,
+	},
+	"time": {
+		Name:       "time",
+		ArgTypes:   []ValueType{},
+		ReturnType: ValueTypeScalar,
+		Call:       funcTime,
+	},
+	"timestamp": {
+		Name:       "timestamp",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		ReturnType: ValueTypeVector,
+		Call:       funcTimestamp,
+	},
+	"vector": {
+		Name:       "vector",
+		ArgTypes:   []ValueType{ValueTypeScalar},
+		ReturnType: ValueTypeVector,
+		Call:       funcVector,
+	},
+	"year": {
+		Name:       "year",
+		ArgTypes:   []ValueType{ValueTypeVector},
+		Variadic:   1,
+		ReturnType: ValueTypeVector,
+		Call:       funcYear,
+	},
+}
+
+// getFunction returns a predefined Function object for the given name.
+func getFunction(name string) (*Function, bool) {
+	function, ok := functions[name]
+	return function, ok
+}
+
+type vectorByValueHeap Vector
+
+func (s vectorByValueHeap) Len() int {
+	return len(s)
+}
+
+func (s vectorByValueHeap) Less(i, j int) bool {
+	if math.IsNaN(float64(s[i].V)) {
+		return true
+	}
+	return s[i].V < s[j].V
+}
+
+func (s vectorByValueHeap) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s *vectorByValueHeap) Push(x interface{}) {
+	*s = append(*s, *(x.(*Sample)))
+}
+
+func (s *vectorByValueHeap) Pop() interface{} {
+	old := *s
+	n := len(old)
+	el := old[n-1]
+	*s = old[0 : n-1]
+	return el
+}
+
+type vectorByReverseValueHeap Vector
+
+func (s vectorByReverseValueHeap) Len() int {
+	return len(s)
+}
+
+func (s vectorByReverseValueHeap) Less(i, j int) bool {
+	if math.IsNaN(float64(s[i].V)) {
+		return true
+	}
+	return s[i].V > s[j].V
+}
+
+func (s vectorByReverseValueHeap) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s *vectorByReverseValueHeap) Push(x interface{}) {
+	*s = append(*s, *(x.(*Sample)))
+}
+
+func (s *vectorByReverseValueHeap) Pop() interface{} {
+	old := *s
+	n := len(old)
+	el := old[n-1]
+	*s = old[0 : n-1]
+	return el
+}

--- a/vendor/github.com/prometheus/prometheus/promql/fuzz.go
+++ b/vendor/github.com/prometheus/prometheus/promql/fuzz.go
@@ -1,0 +1,92 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Only build when go-fuzz is in use
+// +build gofuzz
+
+package promql
+
+import "github.com/prometheus/prometheus/pkg/textparse"
+
+// PromQL parser fuzzing instrumentation for use with
+// https://github.com/dvyukov/go-fuzz.
+//
+// Fuzz each parser by building appropriately instrumented parser, ex.
+// FuzzParseMetric and execute it with it's
+//
+//     go-fuzz-build -func FuzzParseMetric -o FuzzParseMetric.zip github.com/prometheus/prometheus/promql
+//
+// And then run the tests with the appropriate inputs
+//
+//     go-fuzz -bin FuzzParseMetric.zip -workdir fuzz-data/ParseMetric
+//
+// Further input samples should go in the folders fuzz-data/ParseMetric/corpus.
+//
+// Repeat for ParseMetricSeletion, ParseExpr and ParseStmt.
+
+// Tuning which value is returned from Fuzz*-functions has a strong influence
+// on how quick the fuzzer converges on "interesting" cases. At least try
+// switching between fuzzMeh (= included in corpus, but not a priority) and
+// fuzzDiscard (=don't use this input for re-building later inputs) when
+// experimenting.
+const (
+	fuzzInteresting = 1
+	fuzzMeh         = 0
+	fuzzDiscard     = -1
+)
+
+// Fuzz the metric parser.
+//
+// Note that his is not the parser for the text-based exposition-format; that
+// lives in github.com/prometheus/client_golang/text.
+func FuzzParseMetric(in []byte) int {
+	p := textparse.New(in)
+	for p.Next() {
+	}
+
+	if p.Err() == nil {
+		return fuzzInteresting
+	}
+
+	return fuzzMeh
+}
+
+// Fuzz the metric selector parser.
+func FuzzParseMetricSelector(in []byte) int {
+	_, err := ParseMetricSelector(string(in))
+	if err == nil {
+		return fuzzInteresting
+	}
+
+	return fuzzMeh
+}
+
+// Fuzz the expression parser.
+func FuzzParseExpr(in []byte) int {
+	_, err := ParseExpr(string(in))
+	if err == nil {
+		return fuzzInteresting
+	}
+
+	return fuzzMeh
+}
+
+// Fuzz the parser.
+func FuzzParseStmts(in []byte) int {
+	_, err := ParseStmts(string(in))
+	if err == nil {
+		return fuzzInteresting
+	}
+
+	return fuzzMeh
+}

--- a/vendor/github.com/prometheus/prometheus/promql/lex.go
+++ b/vendor/github.com/prometheus/prometheus/promql/lex.go
@@ -1,0 +1,906 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// item represents a token or text string returned from the scanner.
+type item struct {
+	typ ItemType // The type of this item.
+	pos Pos      // The starting position, in bytes, of this item in the input string.
+	val string   // The value of this item.
+}
+
+// String returns a descriptive string for the item.
+func (i item) String() string {
+	switch {
+	case i.typ == itemEOF:
+		return "EOF"
+	case i.typ == itemError:
+		return i.val
+	case i.typ == itemIdentifier || i.typ == itemMetricIdentifier:
+		return fmt.Sprintf("%q", i.val)
+	case i.typ.isKeyword():
+		return fmt.Sprintf("<%s>", i.val)
+	case i.typ.isOperator():
+		return fmt.Sprintf("<op:%s>", i.val)
+	case i.typ.isAggregator():
+		return fmt.Sprintf("<aggr:%s>", i.val)
+	case len(i.val) > 10:
+		return fmt.Sprintf("%.10q...", i.val)
+	}
+	return fmt.Sprintf("%q", i.val)
+}
+
+// isOperator returns true if the item corresponds to a arithmetic or set operator.
+// Returns false otherwise.
+func (i ItemType) isOperator() bool { return i > operatorsStart && i < operatorsEnd }
+
+// isAggregator returns true if the item belongs to the aggregator functions.
+// Returns false otherwise
+func (i ItemType) isAggregator() bool { return i > aggregatorsStart && i < aggregatorsEnd }
+
+// isAggregator returns true if the item is an aggregator that takes a parameter.
+// Returns false otherwise
+func (i ItemType) isAggregatorWithParam() bool {
+	return i == itemTopK || i == itemBottomK || i == itemCountValues || i == itemQuantile
+}
+
+// isKeyword returns true if the item corresponds to a keyword.
+// Returns false otherwise.
+func (i ItemType) isKeyword() bool { return i > keywordsStart && i < keywordsEnd }
+
+// isCompairsonOperator returns true if the item corresponds to a comparison operator.
+// Returns false otherwise.
+func (i ItemType) isComparisonOperator() bool {
+	switch i {
+	case itemEQL, itemNEQ, itemLTE, itemLSS, itemGTE, itemGTR:
+		return true
+	default:
+		return false
+	}
+}
+
+// isSetOperator returns whether the item corresponds to a set operator.
+func (i ItemType) isSetOperator() bool {
+	switch i {
+	case itemLAND, itemLOR, itemLUnless:
+		return true
+	}
+	return false
+}
+
+// LowestPrec is a constant for operator precedence in expressions.
+const LowestPrec = 0 // Non-operators.
+
+// Precedence returns the operator precedence of the binary
+// operator op. If op is not a binary operator, the result
+// is LowestPrec.
+func (i ItemType) precedence() int {
+	switch i {
+	case itemLOR:
+		return 1
+	case itemLAND, itemLUnless:
+		return 2
+	case itemEQL, itemNEQ, itemLTE, itemLSS, itemGTE, itemGTR:
+		return 3
+	case itemADD, itemSUB:
+		return 4
+	case itemMUL, itemDIV, itemMOD:
+		return 5
+	case itemPOW:
+		return 6
+	default:
+		return LowestPrec
+	}
+}
+
+func (i ItemType) isRightAssociative() bool {
+	switch i {
+	case itemPOW:
+		return true
+	default:
+		return false
+	}
+
+}
+
+type ItemType int
+
+const (
+	itemError ItemType = iota // Error occurred, value is error message
+	itemEOF
+	itemComment
+	itemIdentifier
+	itemMetricIdentifier
+	itemLeftParen
+	itemRightParen
+	itemLeftBrace
+	itemRightBrace
+	itemLeftBracket
+	itemRightBracket
+	itemComma
+	itemAssign
+	itemSemicolon
+	itemString
+	itemNumber
+	itemDuration
+	itemBlank
+	itemTimes
+
+	operatorsStart
+	// Operators.
+	itemSUB
+	itemADD
+	itemMUL
+	itemMOD
+	itemDIV
+	itemLAND
+	itemLOR
+	itemLUnless
+	itemEQL
+	itemNEQ
+	itemLTE
+	itemLSS
+	itemGTE
+	itemGTR
+	itemEQLRegex
+	itemNEQRegex
+	itemPOW
+	operatorsEnd
+
+	aggregatorsStart
+	// Aggregators.
+	itemAvg
+	itemCount
+	itemSum
+	itemMin
+	itemMax
+	itemStddev
+	itemStdvar
+	itemTopK
+	itemBottomK
+	itemCountValues
+	itemQuantile
+	aggregatorsEnd
+
+	keywordsStart
+	// Keywords.
+	itemAlert
+	itemIf
+	itemFor
+	itemLabels
+	itemAnnotations
+	itemOffset
+	itemBy
+	itemWithout
+	itemOn
+	itemIgnoring
+	itemGroupLeft
+	itemGroupRight
+	itemBool
+	keywordsEnd
+)
+
+var key = map[string]ItemType{
+	// Operators.
+	"and":    itemLAND,
+	"or":     itemLOR,
+	"unless": itemLUnless,
+
+	// Aggregators.
+	"sum":          itemSum,
+	"avg":          itemAvg,
+	"count":        itemCount,
+	"min":          itemMin,
+	"max":          itemMax,
+	"stddev":       itemStddev,
+	"stdvar":       itemStdvar,
+	"topk":         itemTopK,
+	"bottomk":      itemBottomK,
+	"count_values": itemCountValues,
+	"quantile":     itemQuantile,
+
+	// Keywords.
+	"alert":       itemAlert,
+	"if":          itemIf,
+	"for":         itemFor,
+	"labels":      itemLabels,
+	"annotations": itemAnnotations,
+	"offset":      itemOffset,
+	"by":          itemBy,
+	"without":     itemWithout,
+	"on":          itemOn,
+	"ignoring":    itemIgnoring,
+	"group_left":  itemGroupLeft,
+	"group_right": itemGroupRight,
+	"bool":        itemBool,
+}
+
+// These are the default string representations for common items. It does not
+// imply that those are the only character sequences that can be lexed to such an item.
+var itemTypeStr = map[ItemType]string{
+	itemLeftParen:    "(",
+	itemRightParen:   ")",
+	itemLeftBrace:    "{",
+	itemRightBrace:   "}",
+	itemLeftBracket:  "[",
+	itemRightBracket: "]",
+	itemComma:        ",",
+	itemAssign:       "=",
+	itemSemicolon:    ";",
+	itemBlank:        "_",
+	itemTimes:        "x",
+
+	itemSUB:      "-",
+	itemADD:      "+",
+	itemMUL:      "*",
+	itemMOD:      "%",
+	itemDIV:      "/",
+	itemEQL:      "==",
+	itemNEQ:      "!=",
+	itemLTE:      "<=",
+	itemLSS:      "<",
+	itemGTE:      ">=",
+	itemGTR:      ">",
+	itemEQLRegex: "=~",
+	itemNEQRegex: "!~",
+	itemPOW:      "^",
+}
+
+func init() {
+	// Add keywords to item type strings.
+	for s, ty := range key {
+		itemTypeStr[ty] = s
+	}
+	// Special numbers.
+	key["inf"] = itemNumber
+	key["nan"] = itemNumber
+}
+
+func (i ItemType) String() string {
+	if s, ok := itemTypeStr[i]; ok {
+		return s
+	}
+	return fmt.Sprintf("<item %d>", i)
+}
+
+func (i item) desc() string {
+	if _, ok := itemTypeStr[i.typ]; ok {
+		return i.String()
+	}
+	if i.typ == itemEOF {
+		return i.typ.desc()
+	}
+	return fmt.Sprintf("%s %s", i.typ.desc(), i)
+}
+
+func (i ItemType) desc() string {
+	switch i {
+	case itemError:
+		return "error"
+	case itemEOF:
+		return "end of input"
+	case itemComment:
+		return "comment"
+	case itemIdentifier:
+		return "identifier"
+	case itemMetricIdentifier:
+		return "metric identifier"
+	case itemString:
+		return "string"
+	case itemNumber:
+		return "number"
+	case itemDuration:
+		return "duration"
+	}
+	return fmt.Sprintf("%q", i)
+}
+
+const eof = -1
+
+// stateFn represents the state of the scanner as a function that returns the next state.
+type stateFn func(*lexer) stateFn
+
+// Pos is the position in a string.
+type Pos int
+
+// lexer holds the state of the scanner.
+type lexer struct {
+	input   string    // The string being scanned.
+	state   stateFn   // The next lexing function to enter.
+	pos     Pos       // Current position in the input.
+	start   Pos       // Start position of this item.
+	width   Pos       // Width of last rune read from input.
+	lastPos Pos       // Position of most recent item returned by nextItem.
+	items   chan item // Channel of scanned items.
+
+	parenDepth  int  // Nesting depth of ( ) exprs.
+	braceOpen   bool // Whether a { is opened.
+	bracketOpen bool // Whether a [ is opened.
+	stringOpen  rune // Quote rune of the string currently being read.
+
+	// seriesDesc is set when a series description for the testing
+	// language is lexed.
+	seriesDesc bool
+}
+
+// next returns the next rune in the input.
+func (l *lexer) next() rune {
+	if int(l.pos) >= len(l.input) {
+		l.width = 0
+		return eof
+	}
+	r, w := utf8.DecodeRuneInString(l.input[l.pos:])
+	l.width = Pos(w)
+	l.pos += l.width
+	return r
+}
+
+// peek returns but does not consume the next rune in the input.
+func (l *lexer) peek() rune {
+	r := l.next()
+	l.backup()
+	return r
+}
+
+// backup steps back one rune. Can only be called once per call of next.
+func (l *lexer) backup() {
+	l.pos -= l.width
+}
+
+// emit passes an item back to the client.
+func (l *lexer) emit(t ItemType) {
+	l.items <- item{t, l.start, l.input[l.start:l.pos]}
+	l.start = l.pos
+}
+
+// ignore skips over the pending input before this point.
+func (l *lexer) ignore() {
+	l.start = l.pos
+}
+
+// accept consumes the next rune if it's from the valid set.
+func (l *lexer) accept(valid string) bool {
+	if strings.ContainsRune(valid, l.next()) {
+		return true
+	}
+	l.backup()
+	return false
+}
+
+// acceptRun consumes a run of runes from the valid set.
+func (l *lexer) acceptRun(valid string) {
+	for strings.ContainsRune(valid, l.next()) {
+		// consume
+	}
+	l.backup()
+}
+
+// lineNumber reports which line we're on, based on the position of
+// the previous item returned by nextItem. Doing it this way
+// means we don't have to worry about peek double counting.
+func (l *lexer) lineNumber() int {
+	return 1 + strings.Count(l.input[:l.lastPos], "\n")
+}
+
+// linePosition reports at which character in the current line
+// we are on.
+func (l *lexer) linePosition() int {
+	lb := strings.LastIndex(l.input[:l.lastPos], "\n")
+	if lb == -1 {
+		return 1 + int(l.lastPos)
+	}
+	return 1 + int(l.lastPos) - lb
+}
+
+// errorf returns an error token and terminates the scan by passing
+// back a nil pointer that will be the next state, terminating l.nextItem.
+func (l *lexer) errorf(format string, args ...interface{}) stateFn {
+	l.items <- item{itemError, l.start, fmt.Sprintf(format, args...)}
+	return nil
+}
+
+// nextItem returns the next item from the input.
+func (l *lexer) nextItem() item {
+	item := <-l.items
+	l.lastPos = item.pos
+	return item
+}
+
+// lex creates a new scanner for the input string.
+func lex(input string) *lexer {
+	l := &lexer{
+		input: input,
+		items: make(chan item),
+	}
+	go l.run()
+	return l
+}
+
+// run runs the state machine for the lexer.
+func (l *lexer) run() {
+	for l.state = lexStatements; l.state != nil; {
+		l.state = l.state(l)
+	}
+	close(l.items)
+}
+
+// lineComment is the character that starts a line comment.
+const lineComment = "#"
+
+// lexStatements is the top-level state for lexing.
+func lexStatements(l *lexer) stateFn {
+	if l.braceOpen {
+		return lexInsideBraces
+	}
+	if strings.HasPrefix(l.input[l.pos:], lineComment) {
+		return lexLineComment
+	}
+
+	switch r := l.next(); {
+	case r == eof:
+		if l.parenDepth != 0 {
+			return l.errorf("unclosed left parenthesis")
+		} else if l.bracketOpen {
+			return l.errorf("unclosed left bracket")
+		}
+		l.emit(itemEOF)
+		return nil
+	case r == ',':
+		l.emit(itemComma)
+	case isSpace(r):
+		return lexSpace
+	case r == '*':
+		l.emit(itemMUL)
+	case r == '/':
+		l.emit(itemDIV)
+	case r == '%':
+		l.emit(itemMOD)
+	case r == '+':
+		l.emit(itemADD)
+	case r == '-':
+		l.emit(itemSUB)
+	case r == '^':
+		l.emit(itemPOW)
+	case r == '=':
+		if t := l.peek(); t == '=' {
+			l.next()
+			l.emit(itemEQL)
+		} else if t == '~' {
+			return l.errorf("unexpected character after '=': %q", t)
+		} else {
+			l.emit(itemAssign)
+		}
+	case r == '!':
+		if t := l.next(); t == '=' {
+			l.emit(itemNEQ)
+		} else {
+			return l.errorf("unexpected character after '!': %q", t)
+		}
+	case r == '<':
+		if t := l.peek(); t == '=' {
+			l.next()
+			l.emit(itemLTE)
+		} else {
+			l.emit(itemLSS)
+		}
+	case r == '>':
+		if t := l.peek(); t == '=' {
+			l.next()
+			l.emit(itemGTE)
+		} else {
+			l.emit(itemGTR)
+		}
+	case isDigit(r) || (r == '.' && isDigit(l.peek())):
+		l.backup()
+		return lexNumberOrDuration
+	case r == '"' || r == '\'':
+		l.stringOpen = r
+		return lexString
+	case r == '`':
+		l.stringOpen = r
+		return lexRawString
+	case isAlpha(r) || r == ':':
+		l.backup()
+		return lexKeywordOrIdentifier
+	case r == '(':
+		l.emit(itemLeftParen)
+		l.parenDepth++
+		return lexStatements
+	case r == ')':
+		l.emit(itemRightParen)
+		l.parenDepth--
+		if l.parenDepth < 0 {
+			return l.errorf("unexpected right parenthesis %q", r)
+		}
+		return lexStatements
+	case r == '{':
+		l.emit(itemLeftBrace)
+		l.braceOpen = true
+		return lexInsideBraces(l)
+	case r == '[':
+		if l.bracketOpen {
+			return l.errorf("unexpected left bracket %q", r)
+		}
+		l.emit(itemLeftBracket)
+		l.bracketOpen = true
+		return lexDuration
+	case r == ']':
+		if !l.bracketOpen {
+			return l.errorf("unexpected right bracket %q", r)
+		}
+		l.emit(itemRightBracket)
+		l.bracketOpen = false
+
+	default:
+		return l.errorf("unexpected character: %q", r)
+	}
+	return lexStatements
+}
+
+// lexInsideBraces scans the inside of a vector selector. Keywords are ignored and
+// scanned as identifiers.
+func lexInsideBraces(l *lexer) stateFn {
+	if strings.HasPrefix(l.input[l.pos:], lineComment) {
+		return lexLineComment
+	}
+
+	switch r := l.next(); {
+	case r == eof:
+		return l.errorf("unexpected end of input inside braces")
+	case isSpace(r):
+		return lexSpace
+	case isAlpha(r):
+		l.backup()
+		return lexIdentifier
+	case r == ',':
+		l.emit(itemComma)
+	case r == '"' || r == '\'':
+		l.stringOpen = r
+		return lexString
+	case r == '`':
+		l.stringOpen = r
+		return lexRawString
+	case r == '=':
+		if l.next() == '~' {
+			l.emit(itemEQLRegex)
+			break
+		}
+		l.backup()
+		l.emit(itemEQL)
+	case r == '!':
+		switch nr := l.next(); {
+		case nr == '~':
+			l.emit(itemNEQRegex)
+		case nr == '=':
+			l.emit(itemNEQ)
+		default:
+			return l.errorf("unexpected character after '!' inside braces: %q", nr)
+		}
+	case r == '{':
+		return l.errorf("unexpected left brace %q", r)
+	case r == '}':
+		l.emit(itemRightBrace)
+		l.braceOpen = false
+
+		if l.seriesDesc {
+			return lexValueSequence
+		}
+		return lexStatements
+	default:
+		return l.errorf("unexpected character inside braces: %q", r)
+	}
+	return lexInsideBraces
+}
+
+// lexValueSequence scans a value sequence of a series description.
+func lexValueSequence(l *lexer) stateFn {
+	switch r := l.next(); {
+	case r == eof:
+		return lexStatements
+	case isSpace(r):
+		lexSpace(l)
+	case r == '+':
+		l.emit(itemADD)
+	case r == '-':
+		l.emit(itemSUB)
+	case r == 'x':
+		l.emit(itemTimes)
+	case r == '_':
+		l.emit(itemBlank)
+	case isDigit(r) || (r == '.' && isDigit(l.peek())):
+		l.backup()
+		lexNumber(l)
+	case isAlpha(r):
+		l.backup()
+		// We might lex invalid items here but this will be caught by the parser.
+		return lexKeywordOrIdentifier
+	default:
+		return l.errorf("unexpected character in series sequence: %q", r)
+	}
+	return lexValueSequence
+}
+
+// lexEscape scans a string escape sequence. The initial escaping character (\)
+// has already been seen.
+//
+// NOTE: This function as well as the helper function digitVal() and associated
+// tests have been adapted from the corresponding functions in the "go/scanner"
+// package of the Go standard library to work for Prometheus-style strings.
+// None of the actual escaping/quoting logic was changed in this function - it
+// was only modified to integrate with our lexer.
+func lexEscape(l *lexer) {
+	var n int
+	var base, max uint32
+
+	ch := l.next()
+	switch ch {
+	case 'a', 'b', 'f', 'n', 'r', 't', 'v', '\\', l.stringOpen:
+		return
+	case '0', '1', '2', '3', '4', '5', '6', '7':
+		n, base, max = 3, 8, 255
+	case 'x':
+		ch = l.next()
+		n, base, max = 2, 16, 255
+	case 'u':
+		ch = l.next()
+		n, base, max = 4, 16, unicode.MaxRune
+	case 'U':
+		ch = l.next()
+		n, base, max = 8, 16, unicode.MaxRune
+	case eof:
+		l.errorf("escape sequence not terminated")
+	default:
+		l.errorf("unknown escape sequence %#U", ch)
+	}
+
+	var x uint32
+	for n > 0 {
+		d := uint32(digitVal(ch))
+		if d >= base {
+			if ch == eof {
+				l.errorf("escape sequence not terminated")
+			}
+			l.errorf("illegal character %#U in escape sequence", ch)
+		}
+		x = x*base + d
+		ch = l.next()
+		n--
+	}
+
+	if x > max || 0xD800 <= x && x < 0xE000 {
+		l.errorf("escape sequence is an invalid Unicode code point")
+	}
+}
+
+// digitVal returns the digit value of a rune or 16 in case the rune does not
+// represent a valid digit.
+func digitVal(ch rune) int {
+	switch {
+	case '0' <= ch && ch <= '9':
+		return int(ch - '0')
+	case 'a' <= ch && ch <= 'f':
+		return int(ch - 'a' + 10)
+	case 'A' <= ch && ch <= 'F':
+		return int(ch - 'A' + 10)
+	}
+	return 16 // Larger than any legal digit val.
+}
+
+// lexString scans a quoted string. The initial quote has already been seen.
+func lexString(l *lexer) stateFn {
+Loop:
+	for {
+		switch l.next() {
+		case '\\':
+			lexEscape(l)
+		case utf8.RuneError:
+			return l.errorf("invalid UTF-8 rune")
+		case eof, '\n':
+			return l.errorf("unterminated quoted string")
+		case l.stringOpen:
+			break Loop
+		}
+	}
+	l.emit(itemString)
+	return lexStatements
+}
+
+// lexRawString scans a raw quoted string. The initial quote has already been seen.
+func lexRawString(l *lexer) stateFn {
+Loop:
+	for {
+		switch l.next() {
+		case utf8.RuneError:
+			return l.errorf("invalid UTF-8 rune")
+		case eof:
+			return l.errorf("unterminated raw string")
+		case l.stringOpen:
+			break Loop
+		}
+	}
+	l.emit(itemString)
+	return lexStatements
+}
+
+// lexSpace scans a run of space characters. One space has already been seen.
+func lexSpace(l *lexer) stateFn {
+	for isSpace(l.peek()) {
+		l.next()
+	}
+	l.ignore()
+	return lexStatements
+}
+
+// lexLineComment scans a line comment. Left comment marker is known to be present.
+func lexLineComment(l *lexer) stateFn {
+	l.pos += Pos(len(lineComment))
+	for r := l.next(); !isEndOfLine(r) && r != eof; {
+		r = l.next()
+	}
+	l.backup()
+	l.emit(itemComment)
+	return lexStatements
+}
+
+func lexDuration(l *lexer) stateFn {
+	if l.scanNumber() {
+		return l.errorf("missing unit character in duration")
+	}
+	// Next two chars must be a valid unit and a non-alphanumeric.
+	if l.accept("smhdwy") {
+		if isAlphaNumeric(l.next()) {
+			return l.errorf("bad duration syntax: %q", l.input[l.start:l.pos])
+		}
+		l.backup()
+		l.emit(itemDuration)
+		return lexStatements
+	}
+	return l.errorf("bad duration syntax: %q", l.input[l.start:l.pos])
+}
+
+// lexNumber scans a number: decimal, hex, oct or float.
+func lexNumber(l *lexer) stateFn {
+	if !l.scanNumber() {
+		return l.errorf("bad number syntax: %q", l.input[l.start:l.pos])
+	}
+	l.emit(itemNumber)
+	return lexStatements
+}
+
+// lexNumberOrDuration scans a number or a duration item.
+func lexNumberOrDuration(l *lexer) stateFn {
+	if l.scanNumber() {
+		l.emit(itemNumber)
+		return lexStatements
+	}
+	// Next two chars must be a valid unit and a non-alphanumeric.
+	if l.accept("smhdwy") {
+		if isAlphaNumeric(l.next()) {
+			return l.errorf("bad number or duration syntax: %q", l.input[l.start:l.pos])
+		}
+		l.backup()
+		l.emit(itemDuration)
+		return lexStatements
+	}
+	return l.errorf("bad number or duration syntax: %q", l.input[l.start:l.pos])
+}
+
+// scanNumber scans numbers of different formats. The scanned item is
+// not necessarily a valid number. This case is caught by the parser.
+func (l *lexer) scanNumber() bool {
+	digits := "0123456789"
+	// Disallow hexadecimal in series descriptions as the syntax is ambiguous.
+	if !l.seriesDesc && l.accept("0") && l.accept("xX") {
+		digits = "0123456789abcdefABCDEF"
+	}
+	l.acceptRun(digits)
+	if l.accept(".") {
+		l.acceptRun(digits)
+	}
+	if l.accept("eE") {
+		l.accept("+-")
+		l.acceptRun("0123456789")
+	}
+	// Next thing must not be alphanumeric unless it's the times token
+	// for series repetitions.
+	if r := l.peek(); (l.seriesDesc && r == 'x') || !isAlphaNumeric(r) {
+		return true
+	}
+	return false
+}
+
+// lexIdentifier scans an alphanumeric identifier. The next character
+// is known to be a letter.
+func lexIdentifier(l *lexer) stateFn {
+	for isAlphaNumeric(l.next()) {
+		// absorb
+	}
+	l.backup()
+	l.emit(itemIdentifier)
+	return lexStatements
+}
+
+// lexKeywordOrIdentifier scans an alphanumeric identifier which may contain
+// a colon rune. If the identifier is a keyword the respective keyword item
+// is scanned.
+func lexKeywordOrIdentifier(l *lexer) stateFn {
+Loop:
+	for {
+		switch r := l.next(); {
+		case isAlphaNumeric(r) || r == ':':
+			// absorb.
+		default:
+			l.backup()
+			word := l.input[l.start:l.pos]
+			if kw, ok := key[strings.ToLower(word)]; ok {
+				l.emit(kw)
+			} else if !strings.Contains(word, ":") {
+				l.emit(itemIdentifier)
+			} else {
+				l.emit(itemMetricIdentifier)
+			}
+			break Loop
+		}
+	}
+	if l.seriesDesc && l.peek() != '{' {
+		return lexValueSequence
+	}
+	return lexStatements
+}
+
+func isSpace(r rune) bool {
+	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// isEndOfLine reports whether r is an end-of-line character.
+func isEndOfLine(r rune) bool {
+	return r == '\r' || r == '\n'
+}
+
+// isAlphaNumeric reports whether r is an alphabetic, digit, or underscore.
+func isAlphaNumeric(r rune) bool {
+	return isAlpha(r) || isDigit(r)
+}
+
+// isDigit reports whether r is a digit. Note: we cannot use unicode.IsDigit()
+// instead because that also classifies non-Latin digits as digits. See
+// https://github.com/prometheus/prometheus/issues/939.
+func isDigit(r rune) bool {
+	return '0' <= r && r <= '9'
+}
+
+// isAlpha reports whether r is an alphabetic or underscore.
+func isAlpha(r rune) bool {
+	return r == '_' || ('a' <= r && r <= 'z') || ('A' <= r && r <= 'Z')
+}
+
+// isLabel reports whether the string can be used as label.
+func isLabel(s string) bool {
+	if len(s) == 0 || !isAlpha(rune(s[0])) {
+		return false
+	}
+	for _, c := range s[1:] {
+		if !isAlphaNumeric(c) {
+			return false
+		}
+	}
+	return true
+}

--- a/vendor/github.com/prometheus/prometheus/promql/parse.go
+++ b/vendor/github.com/prometheus/prometheus/promql/parse.go
@@ -1,0 +1,1139 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/pkg/value"
+
+	"github.com/prometheus/prometheus/util/strutil"
+)
+
+type parser struct {
+	lex       *lexer
+	token     [3]item
+	peekCount int
+}
+
+// ParseErr wraps a parsing error with line and position context.
+// If the parsing input was a single line, line will be 0 and omitted
+// from the error string.
+type ParseErr struct {
+	Line, Pos int
+	Err       error
+}
+
+func (e *ParseErr) Error() string {
+	if e.Line == 0 {
+		return fmt.Sprintf("parse error at char %d: %s", e.Pos, e.Err)
+	}
+	return fmt.Sprintf("parse error at line %d, char %d: %s", e.Line, e.Pos, e.Err)
+}
+
+// ParseStmts parses the input and returns the resulting statements or any occurring error.
+func ParseStmts(input string) (Statements, error) {
+	p := newParser(input)
+
+	stmts, err := p.parseStmts()
+	if err != nil {
+		return nil, err
+	}
+	err = p.typecheck(stmts)
+	return stmts, err
+}
+
+// ParseExpr returns the expression parsed from the input.
+func ParseExpr(input string) (Expr, error) {
+	p := newParser(input)
+
+	expr, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	err = p.typecheck(expr)
+	return expr, err
+}
+
+// ParseMetric parses the input into a metric
+func ParseMetric(input string) (m labels.Labels, err error) {
+	p := newParser(input)
+	defer p.recover(&err)
+
+	m = p.metric()
+	if p.peek().typ != itemEOF {
+		p.errorf("could not parse remaining input %.15q...", p.lex.input[p.lex.lastPos:])
+	}
+	return m, nil
+}
+
+// ParseMetricSelector parses the provided textual metric selector into a list of
+// label matchers.
+func ParseMetricSelector(input string) (m []*labels.Matcher, err error) {
+	p := newParser(input)
+	defer p.recover(&err)
+
+	name := ""
+	if t := p.peek().typ; t == itemMetricIdentifier || t == itemIdentifier {
+		name = p.next().val
+	}
+	vs := p.VectorSelector(name)
+	if p.peek().typ != itemEOF {
+		p.errorf("could not parse remaining input %.15q...", p.lex.input[p.lex.lastPos:])
+	}
+	return vs.LabelMatchers, nil
+}
+
+// newParser returns a new parser.
+func newParser(input string) *parser {
+	p := &parser{
+		lex: lex(input),
+	}
+	return p
+}
+
+// parseStmts parses a sequence of statements from the input.
+func (p *parser) parseStmts() (stmts Statements, err error) {
+	defer p.recover(&err)
+	stmts = Statements{}
+
+	for p.peek().typ != itemEOF {
+		if p.peek().typ == itemComment {
+			continue
+		}
+		stmts = append(stmts, p.stmt())
+	}
+	return
+}
+
+// parseExpr parses a single expression from the input.
+func (p *parser) parseExpr() (expr Expr, err error) {
+	defer p.recover(&err)
+
+	for p.peek().typ != itemEOF {
+		if p.peek().typ == itemComment {
+			continue
+		}
+		if expr != nil {
+			p.errorf("could not parse remaining input %.15q...", p.lex.input[p.lex.lastPos:])
+		}
+		expr = p.expr()
+	}
+
+	if expr == nil {
+		p.errorf("no expression found in input")
+	}
+	return
+}
+
+// sequenceValue is an omittable value in a sequence of time series values.
+type sequenceValue struct {
+	value   float64
+	omitted bool
+}
+
+func (v sequenceValue) String() string {
+	if v.omitted {
+		return "_"
+	}
+	return fmt.Sprintf("%f", v.value)
+}
+
+// parseSeriesDesc parses the description of a time series.
+func parseSeriesDesc(input string) (labels.Labels, []sequenceValue, error) {
+	p := newParser(input)
+	p.lex.seriesDesc = true
+
+	return p.parseSeriesDesc()
+}
+
+// parseSeriesDesc parses a description of a time series into its metric and value sequence.
+func (p *parser) parseSeriesDesc() (m labels.Labels, vals []sequenceValue, err error) {
+	defer p.recover(&err)
+
+	m = p.metric()
+
+	const ctx = "series values"
+	for {
+		if p.peek().typ == itemEOF {
+			break
+		}
+
+		// Extract blanks.
+		if p.peek().typ == itemBlank {
+			p.next()
+			times := uint64(1)
+			if p.peek().typ == itemTimes {
+				p.next()
+				times, err = strconv.ParseUint(p.expect(itemNumber, ctx).val, 10, 64)
+				if err != nil {
+					p.errorf("invalid repetition in %s: %s", ctx, err)
+				}
+			}
+			for i := uint64(0); i < times; i++ {
+				vals = append(vals, sequenceValue{omitted: true})
+			}
+			continue
+		}
+
+		// Extract values.
+		sign := 1.0
+		if t := p.peek().typ; t == itemSUB || t == itemADD {
+			if p.next().typ == itemSUB {
+				sign = -1
+			}
+		}
+		var k float64
+		if t := p.peek().typ; t == itemNumber {
+			k = sign * p.number(p.expect(itemNumber, ctx).val)
+		} else if t == itemIdentifier && p.peek().val == "stale" {
+			p.next()
+			k = math.Float64frombits(value.StaleNaN)
+		} else {
+			p.errorf("expected number or 'stale' in %s but got %s (value: %s)", ctx, t.desc(), p.peek())
+		}
+		vals = append(vals, sequenceValue{
+			value: k,
+		})
+
+		// If there are no offset repetitions specified, proceed with the next value.
+		if t := p.peek(); t.typ == itemNumber || t.typ == itemBlank || t.typ == itemIdentifier && t.val == "stale" {
+			continue
+		} else if t.typ == itemEOF {
+			break
+		} else if t.typ != itemADD && t.typ != itemSUB {
+			p.errorf("expected next value or relative expansion in %s but got %s (value: %s)", ctx, t.desc(), p.peek())
+		}
+
+		// Expand the repeated offsets into values.
+		sign = 1.0
+		if p.next().typ == itemSUB {
+			sign = -1.0
+		}
+		offset := sign * p.number(p.expect(itemNumber, ctx).val)
+		p.expect(itemTimes, ctx)
+
+		times, err := strconv.ParseUint(p.expect(itemNumber, ctx).val, 10, 64)
+		if err != nil {
+			p.errorf("invalid repetition in %s: %s", ctx, err)
+		}
+
+		for i := uint64(0); i < times; i++ {
+			k += offset
+			vals = append(vals, sequenceValue{
+				value: k,
+			})
+		}
+	}
+	return m, vals, nil
+}
+
+// typecheck checks correct typing of the parsed statements or expression.
+func (p *parser) typecheck(node Node) (err error) {
+	defer p.recover(&err)
+
+	p.checkType(node)
+	return nil
+}
+
+// next returns the next token.
+func (p *parser) next() item {
+	if p.peekCount > 0 {
+		p.peekCount--
+	} else {
+		t := p.lex.nextItem()
+		// Skip comments.
+		for t.typ == itemComment {
+			t = p.lex.nextItem()
+		}
+		p.token[0] = t
+	}
+	if p.token[p.peekCount].typ == itemError {
+		p.errorf("%s", p.token[p.peekCount].val)
+	}
+	return p.token[p.peekCount]
+}
+
+// peek returns but does not consume the next token.
+func (p *parser) peek() item {
+	if p.peekCount > 0 {
+		return p.token[p.peekCount-1]
+	}
+	p.peekCount = 1
+
+	t := p.lex.nextItem()
+	// Skip comments.
+	for t.typ == itemComment {
+		t = p.lex.nextItem()
+	}
+	p.token[0] = t
+	return p.token[0]
+}
+
+// backup backs the input stream up one token.
+func (p *parser) backup() {
+	p.peekCount++
+}
+
+// errorf formats the error and terminates processing.
+func (p *parser) errorf(format string, args ...interface{}) {
+	p.error(fmt.Errorf(format, args...))
+}
+
+// error terminates processing.
+func (p *parser) error(err error) {
+	perr := &ParseErr{
+		Line: p.lex.lineNumber(),
+		Pos:  p.lex.linePosition(),
+		Err:  err,
+	}
+	if strings.Count(strings.TrimSpace(p.lex.input), "\n") == 0 {
+		perr.Line = 0
+	}
+	panic(perr)
+}
+
+// expect consumes the next token and guarantees it has the required type.
+func (p *parser) expect(exp ItemType, context string) item {
+	token := p.next()
+	if token.typ != exp {
+		p.errorf("unexpected %s in %s, expected %s", token.desc(), context, exp.desc())
+	}
+	return token
+}
+
+// expectOneOf consumes the next token and guarantees it has one of the required types.
+func (p *parser) expectOneOf(exp1, exp2 ItemType, context string) item {
+	token := p.next()
+	if token.typ != exp1 && token.typ != exp2 {
+		p.errorf("unexpected %s in %s, expected %s or %s", token.desc(), context, exp1.desc(), exp2.desc())
+	}
+	return token
+}
+
+var errUnexpected = fmt.Errorf("unexpected error")
+
+// recover is the handler that turns panics into returns from the top level of Parse.
+func (p *parser) recover(errp *error) {
+	e := recover()
+	if e != nil {
+		if _, ok := e.(runtime.Error); ok {
+			// Print the stack trace but do not inhibit the running application.
+			buf := make([]byte, 64<<10)
+			buf = buf[:runtime.Stack(buf, false)]
+
+			fmt.Fprintf(os.Stderr, "parser panic: %v\n%s", e, buf)
+			*errp = errUnexpected
+		} else {
+			*errp = e.(error)
+		}
+	}
+}
+
+// stmt parses any statement.
+//
+// 		alertStatement | recordStatement
+//
+func (p *parser) stmt() Statement {
+	switch tok := p.peek(); tok.typ {
+	case itemAlert:
+		return p.alertStmt()
+	case itemIdentifier, itemMetricIdentifier:
+		return p.recordStmt()
+	}
+	p.errorf("no valid statement detected")
+	return nil
+}
+
+// alertStmt parses an alert rule.
+//
+//		ALERT name IF expr [FOR duration]
+//			[LABELS label_set]
+//			[ANNOTATIONS label_set]
+//
+func (p *parser) alertStmt() *AlertStmt {
+	const ctx = "alert statement"
+
+	p.expect(itemAlert, ctx)
+	name := p.expect(itemIdentifier, ctx)
+	// Alerts require a Vector typed expression.
+	p.expect(itemIf, ctx)
+	expr := p.expr()
+
+	// Optional for clause.
+	var (
+		duration time.Duration
+		err      error
+	)
+	if p.peek().typ == itemFor {
+		p.next()
+		dur := p.expect(itemDuration, ctx)
+		duration, err = parseDuration(dur.val)
+		if err != nil {
+			p.error(err)
+		}
+	}
+
+	var (
+		lset        labels.Labels
+		annotations labels.Labels
+	)
+	if p.peek().typ == itemLabels {
+		p.expect(itemLabels, ctx)
+		lset = p.labelSet()
+	}
+	if p.peek().typ == itemAnnotations {
+		p.expect(itemAnnotations, ctx)
+		annotations = p.labelSet()
+	}
+
+	return &AlertStmt{
+		Name:        name.val,
+		Expr:        expr,
+		Duration:    duration,
+		Labels:      lset,
+		Annotations: annotations,
+	}
+}
+
+// recordStmt parses a recording rule.
+func (p *parser) recordStmt() *RecordStmt {
+	const ctx = "record statement"
+
+	name := p.expectOneOf(itemIdentifier, itemMetricIdentifier, ctx).val
+
+	var lset labels.Labels
+	if p.peek().typ == itemLeftBrace {
+		lset = p.labelSet()
+	}
+
+	p.expect(itemAssign, ctx)
+	expr := p.expr()
+
+	return &RecordStmt{
+		Name:   name,
+		Labels: lset,
+		Expr:   expr,
+	}
+}
+
+// expr parses any expression.
+func (p *parser) expr() Expr {
+	// Parse the starting expression.
+	expr := p.unaryExpr()
+
+	// Loop through the operations and construct a binary operation tree based
+	// on the operators' precedence.
+	for {
+		// If the next token is not an operator the expression is done.
+		op := p.peek().typ
+		if !op.isOperator() {
+			return expr
+		}
+		p.next() // Consume operator.
+
+		// Parse optional operator matching options. Its validity
+		// is checked in the type-checking stage.
+		vecMatching := &VectorMatching{
+			Card: CardOneToOne,
+		}
+		if op.isSetOperator() {
+			vecMatching.Card = CardManyToMany
+		}
+
+		returnBool := false
+		// Parse bool modifier.
+		if p.peek().typ == itemBool {
+			if !op.isComparisonOperator() {
+				p.errorf("bool modifier can only be used on comparison operators")
+			}
+			p.next()
+			returnBool = true
+		}
+
+		// Parse ON/IGNORING clause.
+		if p.peek().typ == itemOn || p.peek().typ == itemIgnoring {
+			if p.peek().typ == itemOn {
+				vecMatching.On = true
+			}
+			p.next()
+			vecMatching.MatchingLabels = p.labels()
+
+			// Parse grouping.
+			if t := p.peek().typ; t == itemGroupLeft || t == itemGroupRight {
+				p.next()
+				if t == itemGroupLeft {
+					vecMatching.Card = CardManyToOne
+				} else {
+					vecMatching.Card = CardOneToMany
+				}
+				if p.peek().typ == itemLeftParen {
+					vecMatching.Include = p.labels()
+				}
+			}
+		}
+
+		for _, ln := range vecMatching.MatchingLabels {
+			for _, ln2 := range vecMatching.Include {
+				if ln == ln2 && vecMatching.On {
+					p.errorf("label %q must not occur in ON and GROUP clause at once", ln)
+				}
+			}
+		}
+
+		// Parse the next operand.
+		rhs := p.unaryExpr()
+
+		// Assign the new root based on the precedence of the LHS and RHS operators.
+		expr = p.balance(expr, op, rhs, vecMatching, returnBool)
+	}
+}
+
+func (p *parser) balance(lhs Expr, op ItemType, rhs Expr, vecMatching *VectorMatching, returnBool bool) *BinaryExpr {
+	if lhsBE, ok := lhs.(*BinaryExpr); ok {
+		precd := lhsBE.Op.precedence() - op.precedence()
+		if (precd < 0) || (precd == 0 && op.isRightAssociative()) {
+			balanced := p.balance(lhsBE.RHS, op, rhs, vecMatching, returnBool)
+			if lhsBE.Op.isComparisonOperator() && !lhsBE.ReturnBool && balanced.Type() == ValueTypeScalar && lhsBE.LHS.Type() == ValueTypeScalar {
+				p.errorf("comparisons between scalars must use BOOL modifier")
+			}
+			return &BinaryExpr{
+				Op:             lhsBE.Op,
+				LHS:            lhsBE.LHS,
+				RHS:            balanced,
+				VectorMatching: lhsBE.VectorMatching,
+				ReturnBool:     lhsBE.ReturnBool,
+			}
+		}
+	}
+	if op.isComparisonOperator() && !returnBool && rhs.Type() == ValueTypeScalar && lhs.Type() == ValueTypeScalar {
+		p.errorf("comparisons between scalars must use BOOL modifier")
+	}
+	return &BinaryExpr{
+		Op:             op,
+		LHS:            lhs,
+		RHS:            rhs,
+		VectorMatching: vecMatching,
+		ReturnBool:     returnBool,
+	}
+}
+
+// unaryExpr parses a unary expression.
+//
+//		<Vector_selector> | <Matrix_selector> | (+|-) <number_literal> | '(' <expr> ')'
+//
+func (p *parser) unaryExpr() Expr {
+	switch t := p.peek(); t.typ {
+	case itemADD, itemSUB:
+		p.next()
+		e := p.unaryExpr()
+
+		// Simplify unary expressions for number literals.
+		if nl, ok := e.(*NumberLiteral); ok {
+			if t.typ == itemSUB {
+				nl.Val *= -1
+			}
+			return nl
+		}
+		return &UnaryExpr{Op: t.typ, Expr: e}
+
+	case itemLeftParen:
+		p.next()
+		e := p.expr()
+		p.expect(itemRightParen, "paren expression")
+
+		return &ParenExpr{Expr: e}
+	}
+	e := p.primaryExpr()
+
+	// Expression might be followed by a range selector.
+	if p.peek().typ == itemLeftBracket {
+		vs, ok := e.(*VectorSelector)
+		if !ok {
+			p.errorf("range specification must be preceded by a metric selector, but follows a %T instead", e)
+		}
+		e = p.rangeSelector(vs)
+	}
+
+	// Parse optional offset.
+	if p.peek().typ == itemOffset {
+		offset := p.offset()
+
+		switch s := e.(type) {
+		case *VectorSelector:
+			s.Offset = offset
+		case *MatrixSelector:
+			s.Offset = offset
+		default:
+			p.errorf("offset modifier must be preceded by an instant or range selector, but follows a %T instead", e)
+		}
+	}
+
+	return e
+}
+
+// rangeSelector parses a Matrix (a.k.a. range) selector based on a given
+// Vector selector.
+//
+//		<Vector_selector> '[' <duration> ']'
+//
+func (p *parser) rangeSelector(vs *VectorSelector) *MatrixSelector {
+	const ctx = "range selector"
+	p.next()
+
+	var erange time.Duration
+	var err error
+
+	erangeStr := p.expect(itemDuration, ctx).val
+	erange, err = parseDuration(erangeStr)
+	if err != nil {
+		p.error(err)
+	}
+
+	p.expect(itemRightBracket, ctx)
+
+	e := &MatrixSelector{
+		Name:          vs.Name,
+		LabelMatchers: vs.LabelMatchers,
+		Range:         erange,
+	}
+	return e
+}
+
+// number parses a number.
+func (p *parser) number(val string) float64 {
+	n, err := strconv.ParseInt(val, 0, 64)
+	f := float64(n)
+	if err != nil {
+		f, err = strconv.ParseFloat(val, 64)
+	}
+	if err != nil {
+		p.errorf("error parsing number: %s", err)
+	}
+	return f
+}
+
+// primaryExpr parses a primary expression.
+//
+//		<metric_name> | <function_call> | <Vector_aggregation> | <literal>
+//
+func (p *parser) primaryExpr() Expr {
+	switch t := p.next(); {
+	case t.typ == itemNumber:
+		f := p.number(t.val)
+		return &NumberLiteral{f}
+
+	case t.typ == itemString:
+		return &StringLiteral{p.unquoteString(t.val)}
+
+	case t.typ == itemLeftBrace:
+		// Metric selector without metric name.
+		p.backup()
+		return p.VectorSelector("")
+
+	case t.typ == itemIdentifier:
+		// Check for function call.
+		if p.peek().typ == itemLeftParen {
+			return p.call(t.val)
+		}
+		fallthrough // Else metric selector.
+
+	case t.typ == itemMetricIdentifier:
+		return p.VectorSelector(t.val)
+
+	case t.typ.isAggregator():
+		p.backup()
+		return p.aggrExpr()
+
+	default:
+		p.errorf("no valid expression found")
+	}
+	return nil
+}
+
+// labels parses a list of labelnames.
+//
+//		'(' <label_name>, ... ')'
+//
+func (p *parser) labels() []string {
+	const ctx = "grouping opts"
+
+	p.expect(itemLeftParen, ctx)
+
+	labels := []string{}
+	if p.peek().typ != itemRightParen {
+		for {
+			id := p.next()
+			if !isLabel(id.val) {
+				p.errorf("unexpected %s in %s, expected label", id.desc(), ctx)
+			}
+			labels = append(labels, id.val)
+
+			if p.peek().typ != itemComma {
+				break
+			}
+			p.next()
+		}
+	}
+	p.expect(itemRightParen, ctx)
+
+	return labels
+}
+
+// aggrExpr parses an aggregation expression.
+//
+//		<aggr_op> (<Vector_expr>) [by|without <labels>]
+//		<aggr_op> [by|without <labels>] (<Vector_expr>)
+//
+func (p *parser) aggrExpr() *AggregateExpr {
+	const ctx = "aggregation"
+
+	agop := p.next()
+	if !agop.typ.isAggregator() {
+		p.errorf("expected aggregation operator but got %s", agop)
+	}
+	var grouping []string
+	var without bool
+
+	modifiersFirst := false
+
+	if t := p.peek().typ; t == itemBy || t == itemWithout {
+		if t == itemWithout {
+			without = true
+		}
+		p.next()
+		grouping = p.labels()
+		modifiersFirst = true
+	}
+
+	p.expect(itemLeftParen, ctx)
+	var param Expr
+	if agop.typ.isAggregatorWithParam() {
+		param = p.expr()
+		p.expect(itemComma, ctx)
+	}
+	e := p.expr()
+	p.expect(itemRightParen, ctx)
+
+	if !modifiersFirst {
+		if t := p.peek().typ; t == itemBy || t == itemWithout {
+			if len(grouping) > 0 {
+				p.errorf("aggregation must only contain one grouping clause")
+			}
+			if t == itemWithout {
+				without = true
+			}
+			p.next()
+			grouping = p.labels()
+		}
+	}
+
+	return &AggregateExpr{
+		Op:       agop.typ,
+		Expr:     e,
+		Param:    param,
+		Grouping: grouping,
+		Without:  without,
+	}
+}
+
+// call parses a function call.
+//
+//		<func_name> '(' [ <arg_expr>, ...] ')'
+//
+func (p *parser) call(name string) *Call {
+	const ctx = "function call"
+
+	fn, exist := getFunction(name)
+	if !exist {
+		p.errorf("unknown function with name %q", name)
+	}
+
+	p.expect(itemLeftParen, ctx)
+	// Might be call without args.
+	if p.peek().typ == itemRightParen {
+		p.next() // Consume.
+		return &Call{fn, nil}
+	}
+
+	var args []Expr
+	for {
+		e := p.expr()
+		args = append(args, e)
+
+		// Terminate if no more arguments.
+		if p.peek().typ != itemComma {
+			break
+		}
+		p.next()
+	}
+
+	// Call must be closed.
+	p.expect(itemRightParen, ctx)
+
+	return &Call{Func: fn, Args: args}
+}
+
+// labelSet parses a set of label matchers
+//
+//		'{' [ <labelname> '=' <match_string>, ... ] '}'
+//
+func (p *parser) labelSet() labels.Labels {
+	set := []labels.Label{}
+	for _, lm := range p.labelMatchers(itemEQL) {
+		set = append(set, labels.Label{Name: lm.Name, Value: lm.Value})
+	}
+	return labels.New(set...)
+}
+
+// labelMatchers parses a set of label matchers.
+//
+//		'{' [ <labelname> <match_op> <match_string>, ... ] '}'
+//
+func (p *parser) labelMatchers(operators ...ItemType) []*labels.Matcher {
+	const ctx = "label matching"
+
+	matchers := []*labels.Matcher{}
+
+	p.expect(itemLeftBrace, ctx)
+
+	// Check if no matchers are provided.
+	if p.peek().typ == itemRightBrace {
+		p.next()
+		return matchers
+	}
+
+	for {
+		label := p.expect(itemIdentifier, ctx)
+
+		op := p.next().typ
+		if !op.isOperator() {
+			p.errorf("expected label matching operator but got %s", op)
+		}
+		var validOp = false
+		for _, allowedOp := range operators {
+			if op == allowedOp {
+				validOp = true
+			}
+		}
+		if !validOp {
+			p.errorf("operator must be one of %q, is %q", operators, op)
+		}
+
+		val := p.unquoteString(p.expect(itemString, ctx).val)
+
+		// Map the item to the respective match type.
+		var matchType labels.MatchType
+		switch op {
+		case itemEQL:
+			matchType = labels.MatchEqual
+		case itemNEQ:
+			matchType = labels.MatchNotEqual
+		case itemEQLRegex:
+			matchType = labels.MatchRegexp
+		case itemNEQRegex:
+			matchType = labels.MatchNotRegexp
+		default:
+			p.errorf("item %q is not a metric match type", op)
+		}
+
+		m, err := labels.NewMatcher(matchType, label.val, val)
+		if err != nil {
+			p.error(err)
+		}
+
+		matchers = append(matchers, m)
+
+		if p.peek().typ == itemIdentifier {
+			p.errorf("missing comma before next identifier %q", p.peek().val)
+		}
+
+		// Terminate list if last matcher.
+		if p.peek().typ != itemComma {
+			break
+		}
+		p.next()
+
+		// Allow comma after each item in a multi-line listing.
+		if p.peek().typ == itemRightBrace {
+			break
+		}
+	}
+
+	p.expect(itemRightBrace, ctx)
+
+	return matchers
+}
+
+// metric parses a metric.
+//
+//		<label_set>
+//		<metric_identifier> [<label_set>]
+//
+func (p *parser) metric() labels.Labels {
+	name := ""
+	var m labels.Labels
+
+	t := p.peek().typ
+	if t == itemIdentifier || t == itemMetricIdentifier {
+		name = p.next().val
+		t = p.peek().typ
+	}
+	if t != itemLeftBrace && name == "" {
+		p.errorf("missing metric name or metric selector")
+	}
+	if t == itemLeftBrace {
+		m = p.labelSet()
+	}
+	if name != "" {
+		m = append(m, labels.Label{Name: labels.MetricName, Value: name})
+		sort.Sort(m)
+	}
+	return m
+}
+
+// offset parses an offset modifier.
+//
+//		offset <duration>
+//
+func (p *parser) offset() time.Duration {
+	const ctx = "offset"
+
+	p.next()
+	offi := p.expect(itemDuration, ctx)
+
+	offset, err := parseDuration(offi.val)
+	if err != nil {
+		p.error(err)
+	}
+
+	return offset
+}
+
+// VectorSelector parses a new (instant) vector selector.
+//
+//		<metric_identifier> [<label_matchers>]
+//		[<metric_identifier>] <label_matchers>
+//
+func (p *parser) VectorSelector(name string) *VectorSelector {
+	var matchers []*labels.Matcher
+	// Parse label matching if any.
+	if t := p.peek(); t.typ == itemLeftBrace {
+		matchers = p.labelMatchers(itemEQL, itemNEQ, itemEQLRegex, itemNEQRegex)
+	}
+	// Metric name must not be set in the label matchers and before at the same time.
+	if name != "" {
+		for _, m := range matchers {
+			if m.Name == labels.MetricName {
+				p.errorf("metric name must not be set twice: %q or %q", name, m.Value)
+			}
+		}
+		// Set name label matching.
+		m, err := labels.NewMatcher(labels.MatchEqual, labels.MetricName, name)
+		if err != nil {
+			panic(err) // Must not happen with metric.Equal.
+		}
+		matchers = append(matchers, m)
+	}
+
+	if len(matchers) == 0 {
+		p.errorf("vector selector must contain label matchers or metric name")
+	}
+	// A Vector selector must contain at least one non-empty matcher to prevent
+	// implicit selection of all metrics (e.g. by a typo).
+	notEmpty := false
+	for _, lm := range matchers {
+		if !lm.Matches("") {
+			notEmpty = true
+			break
+		}
+	}
+	if !notEmpty {
+		p.errorf("vector selector must contain at least one non-empty matcher")
+	}
+
+	return &VectorSelector{
+		Name:          name,
+		LabelMatchers: matchers,
+	}
+}
+
+// expectType checks the type of the node and raises an error if it
+// is not of the expected type.
+func (p *parser) expectType(node Node, want ValueType, context string) {
+	t := p.checkType(node)
+	if t != want {
+		p.errorf("expected type %s in %s, got %s", documentedType(want), context, documentedType(t))
+	}
+}
+
+// check the types of the children of each node and raise an error
+// if they do not form a valid node.
+//
+// Some of these checks are redundant as the the parsing stage does not allow
+// them, but the costs are small and might reveal errors when making changes.
+func (p *parser) checkType(node Node) (typ ValueType) {
+	// For expressions the type is determined by their Type function.
+	// Statements and lists do not have a type but are not invalid either.
+	switch n := node.(type) {
+	case Statements, Expressions, Statement:
+		typ = ValueTypeNone
+	case Expr:
+		typ = n.Type()
+	default:
+		p.errorf("unknown node type: %T", node)
+	}
+
+	// Recursively check correct typing for child nodes and raise
+	// errors in case of bad typing.
+	switch n := node.(type) {
+	case Statements:
+		for _, s := range n {
+			p.expectType(s, ValueTypeNone, "statement list")
+		}
+	case *AlertStmt:
+		p.expectType(n.Expr, ValueTypeVector, "alert statement")
+
+	case *EvalStmt:
+		ty := p.checkType(n.Expr)
+		if ty == ValueTypeNone {
+			p.errorf("evaluation statement must have a valid expression type but got %s", documentedType(ty))
+		}
+
+	case *RecordStmt:
+		ty := p.checkType(n.Expr)
+		if ty != ValueTypeVector && ty != ValueTypeScalar {
+			p.errorf("record statement must have a valid expression of type instant vector or scalar but got %s", documentedType(ty))
+		}
+
+	case Expressions:
+		for _, e := range n {
+			ty := p.checkType(e)
+			if ty == ValueTypeNone {
+				p.errorf("expression must have a valid expression type but got %s", documentedType(ty))
+			}
+		}
+	case *AggregateExpr:
+		if !n.Op.isAggregator() {
+			p.errorf("aggregation operator expected in aggregation expression but got %q", n.Op)
+		}
+		p.expectType(n.Expr, ValueTypeVector, "aggregation expression")
+		if n.Op == itemTopK || n.Op == itemBottomK || n.Op == itemQuantile {
+			p.expectType(n.Param, ValueTypeScalar, "aggregation parameter")
+		}
+		if n.Op == itemCountValues {
+			p.expectType(n.Param, ValueTypeString, "aggregation parameter")
+		}
+
+	case *BinaryExpr:
+		lt := p.checkType(n.LHS)
+		rt := p.checkType(n.RHS)
+
+		if !n.Op.isOperator() {
+			p.errorf("binary expression does not support operator %q", n.Op)
+		}
+		if (lt != ValueTypeScalar && lt != ValueTypeVector) || (rt != ValueTypeScalar && rt != ValueTypeVector) {
+			p.errorf("binary expression must contain only scalar and instant vector types")
+		}
+
+		if (lt != ValueTypeVector || rt != ValueTypeVector) && n.VectorMatching != nil {
+			if len(n.VectorMatching.MatchingLabels) > 0 {
+				p.errorf("vector matching only allowed between instant vectors")
+			}
+			n.VectorMatching = nil
+		} else {
+			// Both operands are Vectors.
+			if n.Op.isSetOperator() {
+				if n.VectorMatching.Card == CardOneToMany || n.VectorMatching.Card == CardManyToOne {
+					p.errorf("no grouping allowed for %q operation", n.Op)
+				}
+				if n.VectorMatching.Card != CardManyToMany {
+					p.errorf("set operations must always be many-to-many")
+				}
+			}
+		}
+
+		if (lt == ValueTypeScalar || rt == ValueTypeScalar) && n.Op.isSetOperator() {
+			p.errorf("set operator %q not allowed in binary scalar expression", n.Op)
+		}
+
+	case *Call:
+		nargs := len(n.Func.ArgTypes)
+		if n.Func.Variadic == 0 {
+			if nargs != len(n.Args) {
+				p.errorf("expected %d argument(s) in call to %q, got %d", nargs, n.Func.Name, len(n.Args))
+			}
+		} else {
+			na := nargs - 1
+			if na > len(n.Args) {
+				p.errorf("expected at least %d argument(s) in call to %q, got %d", na, n.Func.Name, len(n.Args))
+			} else if nargsmax := na + n.Func.Variadic; n.Func.Variadic > 0 && nargsmax < len(n.Args) {
+				p.errorf("expected at most %d argument(s) in call to %q, got %d", nargsmax, n.Func.Name, len(n.Args))
+			}
+		}
+
+		for i, arg := range n.Args {
+			if i >= len(n.Func.ArgTypes) {
+				i = len(n.Func.ArgTypes) - 1
+			}
+			p.expectType(arg, n.Func.ArgTypes[i], fmt.Sprintf("call to function %q", n.Func.Name))
+		}
+
+	case *ParenExpr:
+		p.checkType(n.Expr)
+
+	case *UnaryExpr:
+		if n.Op != itemADD && n.Op != itemSUB {
+			p.errorf("only + and - operators allowed for unary expressions")
+		}
+		if t := p.checkType(n.Expr); t != ValueTypeScalar && t != ValueTypeVector {
+			p.errorf("unary expression only allowed on expressions of type scalar or instant vector, got %q", documentedType(t))
+		}
+
+	case *NumberLiteral, *MatrixSelector, *StringLiteral, *VectorSelector:
+		// Nothing to do for terminals.
+
+	default:
+		p.errorf("unknown node type: %T", node)
+	}
+	return
+}
+
+func (p *parser) unquoteString(s string) string {
+	unquoted, err := strutil.Unquote(s)
+	if err != nil {
+		p.errorf("error unquoting string %q: %s", s, err)
+	}
+	return unquoted
+}
+
+func parseDuration(ds string) (time.Duration, error) {
+	dur, err := model.ParseDuration(ds)
+	if err != nil {
+		return 0, err
+	}
+	if dur == 0 {
+		return 0, fmt.Errorf("duration must be greater than 0")
+	}
+	return time.Duration(dur), nil
+}

--- a/vendor/github.com/prometheus/prometheus/promql/printer.go
+++ b/vendor/github.com/prometheus/prometheus/promql/printer.go
@@ -1,0 +1,234 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// Tree returns a string of the tree structure of the given node.
+func Tree(node Node) string {
+	return tree(node, "")
+}
+
+func tree(node Node, level string) string {
+	if node == nil {
+		return fmt.Sprintf("%s |---- %T\n", level, node)
+	}
+	typs := strings.Split(fmt.Sprintf("%T", node), ".")[1]
+
+	var t string
+	// Only print the number of statements for readability.
+	if stmts, ok := node.(Statements); ok {
+		t = fmt.Sprintf("%s |---- %s :: %d\n", level, typs, len(stmts))
+	} else {
+		t = fmt.Sprintf("%s |---- %s :: %s\n", level, typs, node)
+	}
+
+	level += " · · ·"
+
+	switch n := node.(type) {
+	case Statements:
+		for _, s := range n {
+			t += tree(s, level)
+		}
+	case *AlertStmt:
+		t += tree(n.Expr, level)
+
+	case *EvalStmt:
+		t += tree(n.Expr, level)
+
+	case *RecordStmt:
+		t += tree(n.Expr, level)
+
+	case Expressions:
+		for _, e := range n {
+			t += tree(e, level)
+		}
+	case *AggregateExpr:
+		t += tree(n.Expr, level)
+
+	case *BinaryExpr:
+		t += tree(n.LHS, level)
+		t += tree(n.RHS, level)
+
+	case *Call:
+		t += tree(n.Args, level)
+
+	case *ParenExpr:
+		t += tree(n.Expr, level)
+
+	case *UnaryExpr:
+		t += tree(n.Expr, level)
+
+	case *MatrixSelector, *NumberLiteral, *StringLiteral, *VectorSelector:
+		// nothing to do
+
+	default:
+		panic("promql.Tree: not all node types covered")
+	}
+	return t
+}
+
+func (stmts Statements) String() (s string) {
+	if len(stmts) == 0 {
+		return ""
+	}
+	for _, stmt := range stmts {
+		s += stmt.String()
+		s += "\n\n"
+	}
+	return s[:len(s)-2]
+}
+
+func (node *AlertStmt) String() string {
+	s := fmt.Sprintf("ALERT %s", node.Name)
+	s += fmt.Sprintf("\n\tIF %s", node.Expr)
+	if node.Duration > 0 {
+		s += fmt.Sprintf("\n\tFOR %s", model.Duration(node.Duration))
+	}
+	if len(node.Labels) > 0 {
+		s += fmt.Sprintf("\n\tLABELS %s", node.Labels)
+	}
+	if len(node.Annotations) > 0 {
+		s += fmt.Sprintf("\n\tANNOTATIONS %s", node.Annotations)
+	}
+	return s
+}
+
+func (node *EvalStmt) String() string {
+	return "EVAL " + node.Expr.String()
+}
+
+func (node *RecordStmt) String() string {
+	s := fmt.Sprintf("%s%s = %s", node.Name, node.Labels, node.Expr)
+	return s
+}
+
+func (es Expressions) String() (s string) {
+	if len(es) == 0 {
+		return ""
+	}
+	for _, e := range es {
+		s += e.String()
+		s += ", "
+	}
+	return s[:len(s)-2]
+}
+
+func (node *AggregateExpr) String() string {
+	aggrString := node.Op.String()
+
+	if node.Without {
+		aggrString += fmt.Sprintf(" without(%s) ", strings.Join(node.Grouping, ", "))
+	} else {
+		if len(node.Grouping) > 0 {
+			aggrString += fmt.Sprintf(" by(%s) ", strings.Join(node.Grouping, ", "))
+		}
+	}
+
+	aggrString += "("
+	if node.Op.isAggregatorWithParam() {
+		aggrString += fmt.Sprintf("%s, ", node.Param)
+	}
+	aggrString += fmt.Sprintf("%s)", node.Expr)
+
+	return aggrString
+}
+
+func (node *BinaryExpr) String() string {
+	returnBool := ""
+	if node.ReturnBool {
+		returnBool = " bool"
+	}
+
+	matching := ""
+	vm := node.VectorMatching
+	if vm != nil && (len(vm.MatchingLabels) > 0 || vm.On) {
+		if vm.On {
+			matching = fmt.Sprintf(" on(%s)", strings.Join(vm.MatchingLabels, ", "))
+		} else {
+			matching = fmt.Sprintf(" ignoring(%s)", strings.Join(vm.MatchingLabels, ", "))
+		}
+		if vm.Card == CardManyToOne || vm.Card == CardOneToMany {
+			matching += " group_"
+			if vm.Card == CardManyToOne {
+				matching += "left"
+			} else {
+				matching += "right"
+			}
+			matching += fmt.Sprintf("(%s)", strings.Join(vm.Include, ", "))
+		}
+	}
+	return fmt.Sprintf("%s %s%s%s %s", node.LHS, node.Op, returnBool, matching, node.RHS)
+}
+
+func (node *Call) String() string {
+	return fmt.Sprintf("%s(%s)", node.Func.Name, node.Args)
+}
+
+func (node *MatrixSelector) String() string {
+	vecSelector := &VectorSelector{
+		Name:          node.Name,
+		LabelMatchers: node.LabelMatchers,
+	}
+	offset := ""
+	if node.Offset != time.Duration(0) {
+		offset = fmt.Sprintf(" offset %s", model.Duration(node.Offset))
+	}
+	return fmt.Sprintf("%s[%s]%s", vecSelector.String(), model.Duration(node.Range), offset)
+}
+
+func (node *NumberLiteral) String() string {
+	return fmt.Sprint(node.Val)
+}
+
+func (node *ParenExpr) String() string {
+	return fmt.Sprintf("(%s)", node.Expr)
+}
+
+func (node *StringLiteral) String() string {
+	return fmt.Sprintf("%q", node.Val)
+}
+
+func (node *UnaryExpr) String() string {
+	return fmt.Sprintf("%s%s", node.Op, node.Expr)
+}
+
+func (node *VectorSelector) String() string {
+	labelStrings := make([]string, 0, len(node.LabelMatchers)-1)
+	for _, matcher := range node.LabelMatchers {
+		// Only include the __name__ label if its no equality matching.
+		if matcher.Name == labels.MetricName && matcher.Type == labels.MatchEqual {
+			continue
+		}
+		labelStrings = append(labelStrings, matcher.String())
+	}
+	offset := ""
+	if node.Offset != time.Duration(0) {
+		offset = fmt.Sprintf(" offset %s", model.Duration(node.Offset))
+	}
+
+	if len(labelStrings) == 0 {
+		return fmt.Sprintf("%s%s", node.Name, offset)
+	}
+	sort.Strings(labelStrings)
+	return fmt.Sprintf("%s{%s}%s", node.Name, strings.Join(labelStrings, ","), offset)
+}

--- a/vendor/github.com/prometheus/prometheus/promql/quantile.go
+++ b/vendor/github.com/prometheus/prometheus/promql/quantile.go
@@ -1,0 +1,183 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"math"
+	"sort"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// Helpers to calculate quantiles.
+
+// excludedLabels are the labels to exclude from signature calculation for
+// quantiles.
+var excludedLabels = []string{
+	labels.MetricName,
+	labels.BucketLabel,
+}
+
+type bucket struct {
+	upperBound float64
+	count      float64
+}
+
+// buckets implements sort.Interface.
+type buckets []bucket
+
+func (b buckets) Len() int           { return len(b) }
+func (b buckets) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
+func (b buckets) Less(i, j int) bool { return b[i].upperBound < b[j].upperBound }
+
+type metricWithBuckets struct {
+	metric  labels.Labels
+	buckets buckets
+}
+
+// bucketQuantile calculates the quantile 'q' based on the given buckets. The
+// buckets will be sorted by upperBound by this function (i.e. no sorting
+// needed before calling this function). The quantile value is interpolated
+// assuming a linear distribution within a bucket. However, if the quantile
+// falls into the highest bucket, the upper bound of the 2nd highest bucket is
+// returned. A natural lower bound of 0 is assumed if the upper bound of the
+// lowest bucket is greater 0. In that case, interpolation in the lowest bucket
+// happens linearly between 0 and the upper bound of the lowest bucket.
+// However, if the lowest bucket has an upper bound less or equal 0, this upper
+// bound is returned if the quantile falls into the lowest bucket.
+//
+// There are a number of special cases (once we have a way to report errors
+// happening during evaluations of AST functions, we should report those
+// explicitly):
+//
+// If 'buckets' has fewer than 2 elements, NaN is returned.
+//
+// If the highest bucket is not +Inf, NaN is returned.
+//
+// If q<0, -Inf is returned.
+//
+// If q>1, +Inf is returned.
+func bucketQuantile(q float64, buckets buckets) float64 {
+	if q < 0 {
+		return math.Inf(-1)
+	}
+	if q > 1 {
+		return math.Inf(+1)
+	}
+	if len(buckets) < 2 {
+		return math.NaN()
+	}
+	sort.Sort(buckets)
+	if !math.IsInf(buckets[len(buckets)-1].upperBound, +1) {
+		return math.NaN()
+	}
+
+	ensureMonotonic(buckets)
+
+	rank := q * buckets[len(buckets)-1].count
+	b := sort.Search(len(buckets)-1, func(i int) bool { return buckets[i].count >= rank })
+
+	if b == len(buckets)-1 {
+		return buckets[len(buckets)-2].upperBound
+	}
+	if b == 0 && buckets[0].upperBound <= 0 {
+		return buckets[0].upperBound
+	}
+	var (
+		bucketStart float64
+		bucketEnd   = buckets[b].upperBound
+		count       = buckets[b].count
+	)
+	if b > 0 {
+		bucketStart = buckets[b-1].upperBound
+		count -= buckets[b-1].count
+		rank -= buckets[b-1].count
+	}
+	return bucketStart + (bucketEnd-bucketStart)*float64(rank/count)
+}
+
+// The assumption that bucket counts increase monotonically with increasing
+// upperBound may be violated during:
+//
+//   * Recording rule evaluation of histogram_quantile, especially when rate()
+//      has been applied to the underlying bucket timeseries.
+//   * Evaluation of histogram_quantile computed over federated bucket
+//      timeseries, especially when rate() has been applied.
+//
+// This is because scraped data is not made available to rule evaluation or
+// federation atomically, so some buckets are computed with data from the
+// most recent scrapes, but the other buckets are missing data from the most
+// recent scrape.
+//
+// Monotonicity is usually guaranteed because if a bucket with upper bound
+// u1 has count c1, then any bucket with a higher upper bound u > u1 must
+// have counted all c1 observations and perhaps more, so that c  >= c1.
+//
+// Randomly interspersed partial sampling breaks that guarantee, and rate()
+// exacerbates it. Specifically, suppose bucket le=1000 has a count of 10 from
+// 4 samples but the bucket with le=2000 has a count of 7 from 3 samples. The
+// monotonicity is broken. It is exacerbated by rate() because under normal
+// operation, cumulative counting of buckets will cause the bucket counts to
+// diverge such that small differences from missing samples are not a problem.
+// rate() removes this divergence.)
+//
+// bucketQuantile depends on that monotonicity to do a binary search for the
+// bucket with the φ-quantile count, so breaking the monotonicity
+// guarantee causes bucketQuantile() to return undefined (nonsense) results.
+//
+// As a somewhat hacky solution until ingestion is atomic per scrape, we
+// calculate the "envelope" of the histogram buckets, essentially removing
+// any decreases in the count between successive buckets.
+
+func ensureMonotonic(buckets buckets) {
+	max := buckets[0].count
+	for i := range buckets[1:] {
+		switch {
+		case buckets[i].count > max:
+			max = buckets[i].count
+		case buckets[i].count < max:
+			buckets[i].count = max
+		}
+	}
+}
+
+// qauntile calculates the given quantile of a vector of samples.
+//
+// The Vector will be sorted.
+// If 'values' has zero elements, NaN is returned.
+// If q<0, -Inf is returned.
+// If q>1, +Inf is returned.
+func quantile(q float64, values vectorByValueHeap) float64 {
+	if len(values) == 0 {
+		return math.NaN()
+	}
+	if q < 0 {
+		return math.Inf(-1)
+	}
+	if q > 1 {
+		return math.Inf(+1)
+	}
+	sort.Sort(values)
+
+	n := float64(len(values))
+	// When the quantile lies between two samples,
+	// we use a weighted average of the two samples.
+	rank := q * (n - 1)
+
+	lowerIndex := math.Max(0, math.Floor(rank))
+	upperIndex := math.Min(n-1, lowerIndex+1)
+
+	weight := rank - math.Floor(rank)
+	return float64(values[int(lowerIndex)].V)*(1-weight) + float64(values[int(upperIndex)].V)*weight
+}

--- a/vendor/github.com/prometheus/prometheus/promql/test.go
+++ b/vendor/github.com/prometheus/prometheus/promql/test.go
@@ -1,0 +1,546 @@
+// Copyright 2015 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/prometheus/common/model"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/util/testutil"
+)
+
+var (
+	minNormal = math.Float64frombits(0x0010000000000000) // The smallest positive normal value of type float64.
+
+	patSpace       = regexp.MustCompile("[\t ]+")
+	patLoad        = regexp.MustCompile(`^load\s+(.+?)$`)
+	patEvalInstant = regexp.MustCompile(`^eval(?:_(fail|ordered))?\s+instant\s+(?:at\s+(.+?))?\s+(.+)$`)
+)
+
+const (
+	epsilon = 0.000001 // Relative error allowed for sample values.
+)
+
+var testStartTime = time.Unix(0, 0)
+
+// Test is a sequence of read and write commands that are run
+// against a test storage.
+type Test struct {
+	testutil.T
+
+	cmds []testCommand
+
+	storage storage.Storage
+
+	queryEngine *Engine
+	context     context.Context
+	cancelCtx   context.CancelFunc
+}
+
+// NewTest returns an initialized empty Test.
+func NewTest(t testutil.T, input string) (*Test, error) {
+	test := &Test{
+		T:    t,
+		cmds: []testCommand{},
+	}
+	err := test.parse(input)
+	test.clear()
+
+	return test, err
+}
+
+func newTestFromFile(t testutil.T, filename string) (*Test, error) {
+	content, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return NewTest(t, string(content))
+}
+
+// QueryEngine returns the test's query engine.
+func (t *Test) QueryEngine() *Engine {
+	return t.queryEngine
+}
+
+// Queryable allows querying the test data.
+func (t *Test) Queryable() storage.Queryable {
+	return t.storage
+}
+
+// Context returns the test's context.
+func (t *Test) Context() context.Context {
+	return t.context
+}
+
+// Storage returns the test's storage.
+func (t *Test) Storage() storage.Storage {
+	return t.storage
+}
+
+func raise(line int, format string, v ...interface{}) error {
+	return &ParseErr{
+		Line: line + 1,
+		Err:  fmt.Errorf(format, v...),
+	}
+}
+
+func (t *Test) parseLoad(lines []string, i int) (int, *loadCmd, error) {
+	if !patLoad.MatchString(lines[i]) {
+		return i, nil, raise(i, "invalid load command. (load <step:duration>)")
+	}
+	parts := patLoad.FindStringSubmatch(lines[i])
+
+	gap, err := model.ParseDuration(parts[1])
+	if err != nil {
+		return i, nil, raise(i, "invalid step definition %q: %s", parts[1], err)
+	}
+	cmd := newLoadCmd(time.Duration(gap))
+	for i+1 < len(lines) {
+		i++
+		defLine := lines[i]
+		if len(defLine) == 0 {
+			i--
+			break
+		}
+		metric, vals, err := parseSeriesDesc(defLine)
+		if err != nil {
+			if perr, ok := err.(*ParseErr); ok {
+				perr.Line = i + 1
+			}
+			return i, nil, err
+		}
+		cmd.set(metric, vals...)
+	}
+	return i, cmd, nil
+}
+
+func (t *Test) parseEval(lines []string, i int) (int, *evalCmd, error) {
+	if !patEvalInstant.MatchString(lines[i]) {
+		return i, nil, raise(i, "invalid evaluation command. (eval[_fail|_ordered] instant [at <offset:duration>] <query>")
+	}
+	parts := patEvalInstant.FindStringSubmatch(lines[i])
+	var (
+		mod  = parts[1]
+		at   = parts[2]
+		expr = parts[3]
+	)
+	_, err := ParseExpr(expr)
+	if err != nil {
+		if perr, ok := err.(*ParseErr); ok {
+			perr.Line = i + 1
+			perr.Pos += strings.Index(lines[i], expr)
+		}
+		return i, nil, err
+	}
+
+	offset, err := model.ParseDuration(at)
+	if err != nil {
+		return i, nil, raise(i, "invalid step definition %q: %s", parts[1], err)
+	}
+	ts := testStartTime.Add(time.Duration(offset))
+
+	cmd := newEvalCmd(expr, ts)
+	switch mod {
+	case "ordered":
+		cmd.ordered = true
+	case "fail":
+		cmd.fail = true
+	}
+
+	for j := 1; i+1 < len(lines); j++ {
+		i++
+		defLine := lines[i]
+		if len(defLine) == 0 {
+			i--
+			break
+		}
+		if f, err := parseNumber(defLine); err == nil {
+			cmd.expect(0, nil, sequenceValue{value: f})
+			break
+		}
+		metric, vals, err := parseSeriesDesc(defLine)
+		if err != nil {
+			if perr, ok := err.(*ParseErr); ok {
+				perr.Line = i + 1
+			}
+			return i, nil, err
+		}
+
+		// Currently, we are not expecting any matrices.
+		if len(vals) > 1 {
+			return i, nil, raise(i, "expecting multiple values in instant evaluation not allowed")
+		}
+		cmd.expect(j, metric, vals...)
+	}
+	return i, cmd, nil
+}
+
+// parse the given command sequence and appends it to the test.
+func (t *Test) parse(input string) error {
+	// Trim lines and remove comments.
+	lines := strings.Split(input, "\n")
+	for i, l := range lines {
+		l = strings.TrimSpace(l)
+		if strings.HasPrefix(l, "#") {
+			l = ""
+		}
+		lines[i] = l
+	}
+	var err error
+
+	// Scan for steps line by line.
+	for i := 0; i < len(lines); i++ {
+		l := lines[i]
+		if len(l) == 0 {
+			continue
+		}
+		var cmd testCommand
+
+		switch c := strings.ToLower(patSpace.Split(l, 2)[0]); {
+		case c == "clear":
+			cmd = &clearCmd{}
+		case c == "load":
+			i, cmd, err = t.parseLoad(lines, i)
+		case strings.HasPrefix(c, "eval"):
+			i, cmd, err = t.parseEval(lines, i)
+		default:
+			return raise(i, "invalid command %q", l)
+		}
+		if err != nil {
+			return err
+		}
+		t.cmds = append(t.cmds, cmd)
+	}
+	return nil
+}
+
+// testCommand is an interface that ensures that only the package internal
+// types can be a valid command for a test.
+type testCommand interface {
+	testCmd()
+}
+
+func (*clearCmd) testCmd() {}
+func (*loadCmd) testCmd()  {}
+func (*evalCmd) testCmd()  {}
+
+// loadCmd is a command that loads sequences of sample values for specific
+// metrics into the storage.
+type loadCmd struct {
+	gap     time.Duration
+	metrics map[uint64]labels.Labels
+	defs    map[uint64][]Point
+}
+
+func newLoadCmd(gap time.Duration) *loadCmd {
+	return &loadCmd{
+		gap:     gap,
+		metrics: map[uint64]labels.Labels{},
+		defs:    map[uint64][]Point{},
+	}
+}
+
+func (cmd loadCmd) String() string {
+	return "load"
+}
+
+// set a sequence of sample values for the given metric.
+func (cmd *loadCmd) set(m labels.Labels, vals ...sequenceValue) {
+	h := m.Hash()
+
+	samples := make([]Point, 0, len(vals))
+	ts := testStartTime
+	for _, v := range vals {
+		if !v.omitted {
+			samples = append(samples, Point{
+				T: ts.UnixNano() / int64(time.Millisecond/time.Nanosecond),
+				V: v.value,
+			})
+		}
+		ts = ts.Add(cmd.gap)
+	}
+	cmd.defs[h] = samples
+	cmd.metrics[h] = m
+}
+
+// append the defined time series to the storage.
+func (cmd *loadCmd) append(a storage.Appender) error {
+	for h, smpls := range cmd.defs {
+		m := cmd.metrics[h]
+
+		for _, s := range smpls {
+			if _, err := a.Add(m, s.T, s.V); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// evalCmd is a command that evaluates an expression for the given time (range)
+// and expects a specific result.
+type evalCmd struct {
+	expr  string
+	start time.Time
+
+	fail, ordered bool
+
+	metrics  map[uint64]labels.Labels
+	expected map[uint64]entry
+}
+
+type entry struct {
+	pos  int
+	vals []sequenceValue
+}
+
+func (e entry) String() string {
+	return fmt.Sprintf("%d: %s", e.pos, e.vals)
+}
+
+func newEvalCmd(expr string, start time.Time) *evalCmd {
+	return &evalCmd{
+		expr:  expr,
+		start: start,
+
+		metrics:  map[uint64]labels.Labels{},
+		expected: map[uint64]entry{},
+	}
+}
+
+func (ev *evalCmd) String() string {
+	return "eval"
+}
+
+// expect adds a new metric with a sequence of values to the set of expected
+// results for the query.
+func (ev *evalCmd) expect(pos int, m labels.Labels, vals ...sequenceValue) {
+	if m == nil {
+		ev.expected[0] = entry{pos: pos, vals: vals}
+		return
+	}
+	h := m.Hash()
+	ev.metrics[h] = m
+	ev.expected[h] = entry{pos: pos, vals: vals}
+}
+
+// compareResult compares the result value with the defined expectation.
+func (ev *evalCmd) compareResult(result Value) error {
+	switch val := result.(type) {
+	case Matrix:
+		return fmt.Errorf("received range result on instant evaluation")
+
+	case Vector:
+		seen := map[uint64]bool{}
+		for pos, v := range val {
+			fp := v.Metric.Hash()
+			if _, ok := ev.metrics[fp]; !ok {
+				return fmt.Errorf("unexpected metric %s in result", v.Metric)
+			}
+			exp := ev.expected[fp]
+			if ev.ordered && exp.pos != pos+1 {
+				return fmt.Errorf("expected metric %s with %v at position %d but was at %d", v.Metric, exp.vals, exp.pos, pos+1)
+			}
+			if !almostEqual(exp.vals[0].value, v.V) {
+				return fmt.Errorf("expected %v for %s but got %v", exp.vals[0].value, v.Metric, v.V)
+			}
+
+			seen[fp] = true
+		}
+		for fp, expVals := range ev.expected {
+			if !seen[fp] {
+				fmt.Println("vector result", len(val), ev.expr)
+				for _, ss := range val {
+					fmt.Println("    ", ss.Metric, ss.Point)
+				}
+				return fmt.Errorf("expected metric %s with %v not found", ev.metrics[fp], expVals)
+			}
+		}
+
+	case Scalar:
+		if !almostEqual(ev.expected[0].vals[0].value, val.V) {
+			return fmt.Errorf("expected Scalar %v but got %v", val.V, ev.expected[0].vals[0].value)
+		}
+
+	default:
+		panic(fmt.Errorf("promql.Test.compareResult: unexpected result type %T", result))
+	}
+	return nil
+}
+
+// clearCmd is a command that wipes the test's storage state.
+type clearCmd struct{}
+
+func (cmd clearCmd) String() string {
+	return "clear"
+}
+
+// Run executes the command sequence of the test. Until the maximum error number
+// is reached, evaluation errors do not terminate execution.
+func (t *Test) Run() error {
+	for _, cmd := range t.cmds {
+		err := t.exec(cmd)
+		// TODO(fabxc): aggregate command errors, yield diffs for result
+		// comparison errors.
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// exec processes a single step of the test.
+func (t *Test) exec(tc testCommand) error {
+	switch cmd := tc.(type) {
+	case *clearCmd:
+		t.clear()
+
+	case *loadCmd:
+		app, err := t.storage.Appender()
+		if err != nil {
+			return err
+		}
+		if err := cmd.append(app); err != nil {
+			app.Rollback()
+			return err
+		}
+
+		if err := app.Commit(); err != nil {
+			return err
+		}
+
+	case *evalCmd:
+		q, _ := t.queryEngine.NewInstantQuery(t.storage, cmd.expr, cmd.start)
+		res := q.Exec(t.context)
+		if res.Err != nil {
+			if cmd.fail {
+				return nil
+			}
+			return fmt.Errorf("error evaluating query %q: %s", cmd.expr, res.Err)
+		}
+		defer q.Close()
+		if res.Err == nil && cmd.fail {
+			return fmt.Errorf("expected error evaluating query but got none")
+		}
+
+		err := cmd.compareResult(res.Value)
+		if err != nil {
+			return fmt.Errorf("error in %s %s: %s", cmd, cmd.expr, err)
+		}
+
+		// Check query returns same result in range mode,
+		/// by checking against the middle step.
+		q, _ = t.queryEngine.NewRangeQuery(t.storage, cmd.expr, cmd.start.Add(-time.Minute), cmd.start.Add(time.Minute), time.Minute)
+		rangeRes := q.Exec(t.context)
+		if rangeRes.Err != nil {
+			return fmt.Errorf("error evaluating query %q in range mode: %s", cmd.expr, rangeRes.Err)
+		}
+		defer q.Close()
+		if cmd.ordered {
+			// Ordering isn't defined for range queries.
+			return nil
+		}
+		mat := rangeRes.Value.(Matrix)
+		vec := make(Vector, 0, len(mat))
+		for _, series := range mat {
+			for _, point := range series.Points {
+				if point.T == timeMilliseconds(cmd.start) {
+					vec = append(vec, Sample{Metric: series.Metric, Point: point})
+					break
+				}
+			}
+		}
+		if _, ok := res.Value.(Scalar); ok {
+			err = cmd.compareResult(Scalar{V: vec[0].Point.V})
+		} else {
+			err = cmd.compareResult(vec)
+		}
+		if err != nil {
+			return fmt.Errorf("error in %s %s rande mode: %s", cmd, cmd.expr, err)
+		}
+
+	default:
+		panic("promql.Test.exec: unknown test command type")
+	}
+	return nil
+}
+
+// clear the current test storage of all inserted samples.
+func (t *Test) clear() {
+	if t.storage != nil {
+		if err := t.storage.Close(); err != nil {
+			t.T.Fatalf("closing test storage: %s", err)
+		}
+	}
+	if t.cancelCtx != nil {
+		t.cancelCtx()
+	}
+	t.storage = testutil.NewStorage(t)
+
+	t.queryEngine = NewEngine(nil, nil, 20, 10*time.Second)
+	t.context, t.cancelCtx = context.WithCancel(context.Background())
+}
+
+// Close closes resources associated with the Test.
+func (t *Test) Close() {
+	t.cancelCtx()
+
+	if err := t.storage.Close(); err != nil {
+		t.T.Fatalf("closing test storage: %s", err)
+	}
+}
+
+// samplesAlmostEqual returns true if the two sample lines only differ by a
+// small relative error in their sample value.
+func almostEqual(a, b float64) bool {
+	// NaN has no equality but for testing we still want to know whether both values
+	// are NaN.
+	if math.IsNaN(a) && math.IsNaN(b) {
+		return true
+	}
+
+	// Cf. http://floating-point-gui.de/errors/comparison/
+	if a == b {
+		return true
+	}
+
+	diff := math.Abs(a - b)
+
+	if a == 0 || b == 0 || diff < minNormal {
+		return diff < epsilon*minNormal
+	}
+	return diff/(math.Abs(a)+math.Abs(b)) < epsilon
+}
+
+func parseNumber(s string) (float64, error) {
+	n, err := strconv.ParseInt(s, 0, 64)
+	f := float64(n)
+	if err != nil {
+		f, err = strconv.ParseFloat(s, 64)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("error parsing number: %s", err)
+	}
+	return f, nil
+}

--- a/vendor/github.com/prometheus/prometheus/promql/value.go
+++ b/vendor/github.com/prometheus/prometheus/promql/value.go
@@ -1,0 +1,216 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package promql
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/prometheus/pkg/labels"
+)
+
+// Value is a generic interface for values resulting from a query evaluation.
+type Value interface {
+	Type() ValueType
+	String() string
+}
+
+func (Matrix) Type() ValueType { return ValueTypeMatrix }
+func (Vector) Type() ValueType { return ValueTypeVector }
+func (Scalar) Type() ValueType { return ValueTypeScalar }
+func (String) Type() ValueType { return ValueTypeString }
+
+// ValueType describes a type of a value.
+type ValueType string
+
+// The valid value types.
+const (
+	ValueTypeNone   = "none"
+	ValueTypeVector = "vector"
+	ValueTypeScalar = "scalar"
+	ValueTypeMatrix = "matrix"
+	ValueTypeString = "string"
+)
+
+// String represents a string value.
+type String struct {
+	V string
+	T int64
+}
+
+func (s String) String() string {
+	return s.V
+}
+
+func (s String) MarshalJSON() ([]byte, error) {
+	return json.Marshal([...]interface{}{float64(s.T) / 1000, s.V})
+}
+
+// Scalar is a data point that's explicitly not associated with a metric.
+type Scalar struct {
+	T int64
+	V float64
+}
+
+func (s Scalar) String() string {
+	v := strconv.FormatFloat(s.V, 'f', -1, 64)
+	return fmt.Sprintf("scalar: %v @[%v]", v, s.T)
+}
+
+func (s Scalar) MarshalJSON() ([]byte, error) {
+	v := strconv.FormatFloat(s.V, 'f', -1, 64)
+	return json.Marshal([...]interface{}{float64(s.T) / 1000, v})
+}
+
+// Series is a stream of data points belonging to a metric.
+type Series struct {
+	Metric labels.Labels `json:"metric"`
+	Points []Point       `json:"values"`
+}
+
+func (s Series) String() string {
+	vals := make([]string, len(s.Points))
+	for i, v := range s.Points {
+		vals[i] = v.String()
+	}
+	return fmt.Sprintf("%s =>\n%s", s.Metric, strings.Join(vals, "\n"))
+}
+
+// Point represents a single data point for a given timestamp.
+type Point struct {
+	T int64
+	V float64
+}
+
+func (p Point) String() string {
+	v := strconv.FormatFloat(p.V, 'f', -1, 64)
+	return fmt.Sprintf("%v @[%v]", v, p.T)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (p Point) MarshalJSON() ([]byte, error) {
+	v := strconv.FormatFloat(p.V, 'f', -1, 64)
+	return json.Marshal([...]interface{}{float64(p.T) / 1000, v})
+}
+
+// Sample is a single sample belonging to a metric.
+type Sample struct {
+	Point
+
+	Metric labels.Labels
+}
+
+func (s Sample) String() string {
+	return fmt.Sprintf("%s => %s", s.Metric, s.Point)
+}
+
+func (s Sample) MarshalJSON() ([]byte, error) {
+	v := struct {
+		M labels.Labels `json:"metric"`
+		V Point         `json:"value"`
+	}{
+		M: s.Metric,
+		V: s.Point,
+	}
+	return json.Marshal(v)
+}
+
+// Vector is basically only an alias for model.Samples, but the
+// contract is that in a Vector, all Samples have the same timestamp.
+type Vector []Sample
+
+func (vec Vector) String() string {
+	entries := make([]string, len(vec))
+	for i, s := range vec {
+		entries[i] = s.String()
+	}
+	return strings.Join(entries, "\n")
+}
+
+// Matrix is a slice of Seriess that implements sort.Interface and
+// has a String method.
+type Matrix []Series
+
+func (m Matrix) String() string {
+	// TODO(fabxc): sort, or can we rely on order from the querier?
+	strs := make([]string, len(m))
+
+	for i, ss := range m {
+		strs[i] = ss.String()
+	}
+
+	return strings.Join(strs, "\n")
+}
+
+func (m Matrix) Len() int           { return len(m) }
+func (m Matrix) Less(i, j int) bool { return labels.Compare(m[i].Metric, m[j].Metric) < 0 }
+func (m Matrix) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+// Result holds the resulting value of an execution or an error
+// if any occurred.
+type Result struct {
+	Err   error
+	Value Value
+}
+
+// Vector returns a Vector if the result value is one. An error is returned if
+// the result was an error or the result value is not a Vector.
+func (r *Result) Vector() (Vector, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	v, ok := r.Value.(Vector)
+	if !ok {
+		return nil, fmt.Errorf("query result is not a Vector")
+	}
+	return v, nil
+}
+
+// Matrix returns a Matrix. An error is returned if
+// the result was an error or the result value is not a Matrix.
+func (r *Result) Matrix() (Matrix, error) {
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	v, ok := r.Value.(Matrix)
+	if !ok {
+		return nil, fmt.Errorf("query result is not a range Vector")
+	}
+	return v, nil
+}
+
+// Scalar returns a Scalar value. An error is returned if
+// the result was an error or the result value is not a Scalar.
+func (r *Result) Scalar() (Scalar, error) {
+	if r.Err != nil {
+		return Scalar{}, r.Err
+	}
+	v, ok := r.Value.(Scalar)
+	if !ok {
+		return Scalar{}, fmt.Errorf("query result is not a Scalar")
+	}
+	return v, nil
+}
+
+func (r *Result) String() string {
+	if r.Err != nil {
+		return r.Err.Error()
+	}
+	if r.Value == nil {
+		return ""
+	}
+	return r.Value.String()
+}

--- a/vendor/github.com/prometheus/prometheus/storage/tsdb/tsdb.go
+++ b/vendor/github.com/prometheus/prometheus/storage/tsdb/tsdb.go
@@ -1,0 +1,292 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tsdb
+
+import (
+	"context"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/tsdb"
+	tsdbLabels "github.com/prometheus/tsdb/labels"
+)
+
+// ErrNotReady is returned if the underlying storage is not ready yet.
+var ErrNotReady = errors.New("TSDB not ready")
+
+// ReadyStorage implements the Storage interface while allowing to set the actual
+// storage at a later point in time.
+type ReadyStorage struct {
+	mtx sync.RWMutex
+	a   *adapter
+}
+
+// Set the storage.
+func (s *ReadyStorage) Set(db *tsdb.DB, startTimeMargin int64) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	s.a = &adapter{db: db, startTimeMargin: startTimeMargin}
+}
+
+// Get the storage.
+func (s *ReadyStorage) Get() *tsdb.DB {
+	if x := s.get(); x != nil {
+		return x.db
+	}
+	return nil
+}
+
+func (s *ReadyStorage) get() *adapter {
+	s.mtx.RLock()
+	x := s.a
+	s.mtx.RUnlock()
+	return x
+}
+
+// StartTime implements the Storage interface.
+func (s *ReadyStorage) StartTime() (int64, error) {
+	if x := s.get(); x != nil {
+		return x.StartTime()
+	}
+	return int64(model.Latest), ErrNotReady
+}
+
+// Querier implements the Storage interface.
+func (s *ReadyStorage) Querier(ctx context.Context, mint, maxt int64) (storage.Querier, error) {
+	if x := s.get(); x != nil {
+		return x.Querier(ctx, mint, maxt)
+	}
+	return nil, ErrNotReady
+}
+
+// Appender implements the Storage interface.
+func (s *ReadyStorage) Appender() (storage.Appender, error) {
+	if x := s.get(); x != nil {
+		return x.Appender()
+	}
+	return nil, ErrNotReady
+}
+
+// Close implements the Storage interface.
+func (s *ReadyStorage) Close() error {
+	if x := s.Get(); x != nil {
+		return x.Close()
+	}
+	return nil
+}
+
+// Adapter return an adapter as storage.Storage.
+func Adapter(db *tsdb.DB, startTimeMargin int64) storage.Storage {
+	return &adapter{db: db, startTimeMargin: startTimeMargin}
+}
+
+// adapter implements a storage.Storage around TSDB.
+type adapter struct {
+	db              *tsdb.DB
+	startTimeMargin int64
+}
+
+// Options of the DB storage.
+type Options struct {
+	// The interval at which the write ahead log is flushed to disc.
+	WALFlushInterval time.Duration
+
+	// The timestamp range of head blocks after which they get persisted.
+	// It's the minimum duration of any persisted block.
+	MinBlockDuration model.Duration
+
+	// The maximum timestamp range of compacted blocks.
+	MaxBlockDuration model.Duration
+
+	// Duration for how long to retain data.
+	Retention model.Duration
+
+	// Disable creation and consideration of lockfile.
+	NoLockfile bool
+}
+
+// Open returns a new storage backed by a TSDB database that is configured for Prometheus.
+func Open(path string, l log.Logger, r prometheus.Registerer, opts *Options) (*tsdb.DB, error) {
+	if opts.MinBlockDuration > opts.MaxBlockDuration {
+		opts.MaxBlockDuration = opts.MinBlockDuration
+	}
+	// Start with smallest block duration and create exponential buckets until the exceed the
+	// configured maximum block duration.
+	rngs := tsdb.ExponentialBlockRanges(int64(time.Duration(opts.MinBlockDuration).Seconds()*1000), 10, 3)
+
+	for i, v := range rngs {
+		if v > int64(time.Duration(opts.MaxBlockDuration).Seconds()*1000) {
+			rngs = rngs[:i]
+			break
+		}
+	}
+
+	db, err := tsdb.Open(path, l, r, &tsdb.Options{
+		WALFlushInterval:  10 * time.Second,
+		RetentionDuration: uint64(time.Duration(opts.Retention).Seconds() * 1000),
+		BlockRanges:       rngs,
+		NoLockfile:        opts.NoLockfile,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// StartTime implements the Storage interface.
+func (a adapter) StartTime() (int64, error) {
+	var startTime int64
+
+	if len(a.db.Blocks()) > 0 {
+		startTime = a.db.Blocks()[0].Meta().MinTime
+	} else {
+		startTime = time.Now().Unix() * 1000
+	}
+
+	// Add a safety margin as it may take a few minutes for everything to spin up.
+	return startTime + a.startTimeMargin, nil
+}
+
+func (a adapter) Querier(_ context.Context, mint, maxt int64) (storage.Querier, error) {
+	q, err := a.db.Querier(mint, maxt)
+	if err != nil {
+		return nil, err
+	}
+	return querier{q: q}, nil
+}
+
+// Appender returns a new appender against the storage.
+func (a adapter) Appender() (storage.Appender, error) {
+	return appender{a: a.db.Appender()}, nil
+}
+
+// Close closes the storage and all its underlying resources.
+func (a adapter) Close() error {
+	return a.db.Close()
+}
+
+type querier struct {
+	q tsdb.Querier
+}
+
+func (q querier) Select(_ *storage.SelectParams, oms ...*labels.Matcher) (storage.SeriesSet, error) {
+	ms := make([]tsdbLabels.Matcher, 0, len(oms))
+
+	for _, om := range oms {
+		ms = append(ms, convertMatcher(om))
+	}
+	set, err := q.q.Select(ms...)
+	if err != nil {
+		return nil, err
+	}
+	return seriesSet{set: set}, nil
+}
+
+func (q querier) LabelValues(name string) ([]string, error) { return q.q.LabelValues(name) }
+func (q querier) Close() error                              { return q.q.Close() }
+
+type seriesSet struct {
+	set tsdb.SeriesSet
+}
+
+func (s seriesSet) Next() bool         { return s.set.Next() }
+func (s seriesSet) Err() error         { return s.set.Err() }
+func (s seriesSet) At() storage.Series { return series{s: s.set.At()} }
+
+type series struct {
+	s tsdb.Series
+}
+
+func (s series) Labels() labels.Labels            { return toLabels(s.s.Labels()) }
+func (s series) Iterator() storage.SeriesIterator { return storage.SeriesIterator(s.s.Iterator()) }
+
+type appender struct {
+	a tsdb.Appender
+}
+
+func (a appender) Add(lset labels.Labels, t int64, v float64) (uint64, error) {
+	ref, err := a.a.Add(toTSDBLabels(lset), t, v)
+
+	switch errors.Cause(err) {
+	case tsdb.ErrNotFound:
+		return 0, storage.ErrNotFound
+	case tsdb.ErrOutOfOrderSample:
+		return 0, storage.ErrOutOfOrderSample
+	case tsdb.ErrAmendSample:
+		return 0, storage.ErrDuplicateSampleForTimestamp
+	case tsdb.ErrOutOfBounds:
+		return 0, storage.ErrOutOfBounds
+	}
+	return ref, err
+}
+
+func (a appender) AddFast(_ labels.Labels, ref uint64, t int64, v float64) error {
+	err := a.a.AddFast(ref, t, v)
+
+	switch errors.Cause(err) {
+	case tsdb.ErrNotFound:
+		return storage.ErrNotFound
+	case tsdb.ErrOutOfOrderSample:
+		return storage.ErrOutOfOrderSample
+	case tsdb.ErrAmendSample:
+		return storage.ErrDuplicateSampleForTimestamp
+	case tsdb.ErrOutOfBounds:
+		return storage.ErrOutOfBounds
+	}
+	return err
+}
+
+func (a appender) Commit() error   { return a.a.Commit() }
+func (a appender) Rollback() error { return a.a.Rollback() }
+
+func convertMatcher(m *labels.Matcher) tsdbLabels.Matcher {
+	switch m.Type {
+	case labels.MatchEqual:
+		return tsdbLabels.NewEqualMatcher(m.Name, m.Value)
+
+	case labels.MatchNotEqual:
+		return tsdbLabels.Not(tsdbLabels.NewEqualMatcher(m.Name, m.Value))
+
+	case labels.MatchRegexp:
+		res, err := tsdbLabels.NewRegexpMatcher(m.Name, "^(?:"+m.Value+")$")
+		if err != nil {
+			panic(err)
+		}
+		return res
+
+	case labels.MatchNotRegexp:
+		res, err := tsdbLabels.NewRegexpMatcher(m.Name, "^(?:"+m.Value+")$")
+		if err != nil {
+			panic(err)
+		}
+		return tsdbLabels.Not(res)
+	}
+	panic("storage.convertMatcher: invalid matcher type")
+}
+
+func toTSDBLabels(l labels.Labels) tsdbLabels.Labels {
+	return *(*tsdbLabels.Labels)(unsafe.Pointer(&l))
+}
+
+func toLabels(l tsdbLabels.Labels) labels.Labels {
+	return *(*labels.Labels)(unsafe.Pointer(&l))
+}

--- a/vendor/github.com/prometheus/prometheus/util/stats/query_stats.go
+++ b/vendor/github.com/prometheus/prometheus/util/stats/query_stats.go
@@ -1,0 +1,89 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+// QueryTiming identifies the code area or functionality in which time is spent
+// during a query.
+type QueryTiming int
+
+// Query timings.
+const (
+	EvalTotalTime QueryTiming = iota
+	ResultSortTime
+	QueryPreparationTime
+	InnerEvalTime
+	ExecQueueTime
+	ExecTotalTime
+)
+
+// Return a string representation of a QueryTiming identifier.
+func (s QueryTiming) String() string {
+	switch s {
+	case EvalTotalTime:
+		return "Eval total time"
+	case ResultSortTime:
+		return "Result sorting time"
+	case QueryPreparationTime:
+		return "Query preparation time"
+	case InnerEvalTime:
+		return "Inner eval time"
+	case ExecQueueTime:
+		return "Exec queue wait time"
+	case ExecTotalTime:
+		return "Exec total time"
+	default:
+		return "Unknown query timing"
+	}
+}
+
+// queryTimings with all query timers mapped to durations.
+type queryTimings struct {
+	EvalTotalTime        float64 `json:"evalTotalTime"`
+	ResultSortTime       float64 `json:"resultSortTime"`
+	QueryPreparationTime float64 `json:"queryPreparationTime"`
+	InnerEvalTime        float64 `json:"innerEvalTime"`
+	ExecQueueTime        float64 `json:"execQueueTime"`
+	ExecTotalTime        float64 `json:"execTotalTime"`
+}
+
+// QueryStats currently only holding query timings.
+type QueryStats struct {
+	Timings queryTimings `json:"timings,omitempty"`
+}
+
+// NewQueryStats makes a QueryStats struct with all QueryTimings found in the
+// given TimerGroup.
+func NewQueryStats(tg *TimerGroup) *QueryStats {
+	var qt queryTimings
+
+	for s, timer := range tg.timers {
+		switch s {
+		case EvalTotalTime:
+			qt.EvalTotalTime = timer.Duration()
+		case ResultSortTime:
+			qt.ResultSortTime = timer.Duration()
+		case QueryPreparationTime:
+			qt.QueryPreparationTime = timer.Duration()
+		case InnerEvalTime:
+			qt.InnerEvalTime = timer.Duration()
+		case ExecQueueTime:
+			qt.ExecQueueTime = timer.Duration()
+		case ExecTotalTime:
+			qt.ExecTotalTime = timer.Duration()
+		}
+	}
+
+	qs := QueryStats{Timings: qt}
+	return &qs
+}

--- a/vendor/github.com/prometheus/prometheus/util/stats/timer.go
+++ b/vendor/github.com/prometheus/prometheus/util/stats/timer.go
@@ -1,0 +1,113 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"time"
+)
+
+// A Timer that can be started and stopped and accumulates the total time it
+// was running (the time between Start() and Stop()).
+type Timer struct {
+	name     fmt.Stringer
+	created  time.Time
+	start    time.Time
+	duration time.Duration
+}
+
+// Start the timer.
+func (t *Timer) Start() *Timer {
+	t.start = time.Now()
+	return t
+}
+
+// Stop the timer.
+func (t *Timer) Stop() {
+	t.duration += time.Since(t.start)
+}
+
+// ElapsedTime returns the time that passed since starting the timer.
+func (t *Timer) ElapsedTime() time.Duration {
+	return time.Since(t.start)
+}
+
+// Duration returns the duration value of the timer in seconds.
+func (t *Timer) Duration() float64 {
+	return t.duration.Seconds()
+}
+
+// Return a string representation of the Timer.
+func (t *Timer) String() string {
+	return fmt.Sprintf("%s: %s", t.name, t.duration)
+}
+
+// A TimerGroup represents a group of timers relevant to a single query.
+type TimerGroup struct {
+	timers map[fmt.Stringer]*Timer
+}
+
+// NewTimerGroup constructs a new TimerGroup.
+func NewTimerGroup() *TimerGroup {
+	return &TimerGroup{timers: map[fmt.Stringer]*Timer{}}
+}
+
+// GetTimer gets (and creates, if necessary) the Timer for a given code section.
+func (t *TimerGroup) GetTimer(name fmt.Stringer) *Timer {
+	if timer, exists := t.timers[name]; exists {
+		return timer
+	}
+	timer := &Timer{
+		name:    name,
+		created: time.Now(),
+	}
+	t.timers[name] = timer
+	return timer
+}
+
+// Timers is a slice of Timer pointers that implements Len and Swap from
+// sort.Interface.
+type Timers []*Timer
+
+type byCreationTimeSorter struct{ Timers }
+
+// Len implements sort.Interface.
+func (t Timers) Len() int {
+	return len(t)
+}
+
+// Swap implements sort.Interface.
+func (t Timers) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+func (s byCreationTimeSorter) Less(i, j int) bool {
+	return s.Timers[i].created.Before(s.Timers[j].created)
+}
+
+// Return a string representation of a TimerGroup.
+func (t *TimerGroup) String() string {
+	timers := byCreationTimeSorter{}
+	for _, timer := range t.timers {
+		timers.Timers = append(timers.Timers, timer)
+	}
+	sort.Sort(timers)
+	result := &bytes.Buffer{}
+	for _, timer := range timers.Timers {
+		fmt.Fprintf(result, "%s\n", timer)
+	}
+	return result.String()
+}

--- a/vendor/github.com/prometheus/prometheus/util/testutil/directory.go
+++ b/vendor/github.com/prometheus/prometheus/util/testutil/directory.go
@@ -1,0 +1,129 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+const (
+	// The base directory used for test emissions, which instructs the operating
+	// system to use the default temporary directory as the base or TMPDIR
+	// environment variable.
+	defaultDirectory = ""
+
+	// NilCloser is a no-op Closer.
+	NilCloser = nilCloser(true)
+
+	// The number of times that a TemporaryDirectory will retry its removal
+	temporaryDirectoryRemoveRetries = 2
+)
+
+type (
+	// Closer is the interface that wraps the Close method.
+	Closer interface {
+		// Close reaps the underlying directory and its children. The directory
+		// could be deleted by its users already.
+		Close()
+	}
+
+	nilCloser bool
+
+	// TemporaryDirectory models a closeable path for transient POSIX disk
+	// activities.
+	TemporaryDirectory interface {
+		Closer
+
+		// Path returns the underlying path for access.
+		Path() string
+	}
+
+	// temporaryDirectory is kept as a private type due to private fields and
+	// their interactions.
+	temporaryDirectory struct {
+		path   string
+		tester T
+	}
+
+	callbackCloser struct {
+		fn func()
+	}
+
+	// T implements the needed methods of testing.TB so that we do not need
+	// to actually import testing (which has the side effect of adding all
+	// the test flags, which we do not want in non-test binaries even if
+	// they make use of these utilities for some reason).
+	T interface {
+		Fatal(args ...interface{})
+		Fatalf(format string, args ...interface{})
+	}
+)
+
+func (c nilCloser) Close() {
+}
+
+func (c callbackCloser) Close() {
+	c.fn()
+}
+
+// NewCallbackCloser returns a Closer that calls the provided function upon
+// closing.
+func NewCallbackCloser(fn func()) Closer {
+	return &callbackCloser{
+		fn: fn,
+	}
+}
+
+func (t temporaryDirectory) Close() {
+	retries := temporaryDirectoryRemoveRetries
+	err := os.RemoveAll(t.path)
+	for err != nil && retries > 0 {
+		switch {
+		case os.IsNotExist(err):
+			err = nil
+		default:
+			retries--
+			err = os.RemoveAll(t.path)
+		}
+	}
+	if err != nil {
+		t.tester.Fatal(err)
+	}
+}
+
+func (t temporaryDirectory) Path() string {
+	return t.path
+}
+
+// NewTemporaryDirectory creates a new temporary directory for transient POSIX
+// activities.
+func NewTemporaryDirectory(name string, t T) (handler TemporaryDirectory) {
+	var (
+		directory string
+		err       error
+	)
+
+	directory, err = ioutil.TempDir(defaultDirectory, name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler = temporaryDirectory{
+		path:   directory,
+		tester: t,
+	}
+
+	return
+}

--- a/vendor/github.com/prometheus/prometheus/util/testutil/error.go
+++ b/vendor/github.com/prometheus/prometheus/util/testutil/error.go
@@ -1,0 +1,27 @@
+// Copyright 2013 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+// ErrorEqual compares Go errors for equality.
+func ErrorEqual(left, right error) bool {
+	if left == right {
+		return true
+	}
+
+	if left != nil && right != nil {
+		return left.Error() == right.Error()
+	}
+
+	return false
+}

--- a/vendor/github.com/prometheus/prometheus/util/testutil/roundtrip.go
+++ b/vendor/github.com/prometheus/prometheus/util/testutil/roundtrip.go
@@ -1,0 +1,47 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"net/http"
+)
+
+type roundTrip struct {
+	theResponse *http.Response
+	theError    error
+}
+
+func (rt *roundTrip) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt.theResponse, rt.theError
+}
+
+type roundTripCheckRequest struct {
+	checkRequest func(*http.Request)
+	roundTrip
+}
+
+func (rt *roundTripCheckRequest) RoundTrip(r *http.Request) (*http.Response, error) {
+	rt.checkRequest(r)
+	return rt.theResponse, rt.theError
+}
+
+// NewRoundTripCheckRequest creates a new instance of a type that implements http.RoundTripper,
+// which before returning theResponse and theError, executes checkRequest against a http.Request.
+func NewRoundTripCheckRequest(checkRequest func(*http.Request), theResponse *http.Response, theError error) http.RoundTripper {
+	return &roundTripCheckRequest{
+		checkRequest: checkRequest,
+		roundTrip: roundTrip{
+			theResponse: theResponse,
+			theError:    theError}}
+}

--- a/vendor/github.com/prometheus/prometheus/util/testutil/storage.go
+++ b/vendor/github.com/prometheus/prometheus/util/testutil/storage.go
@@ -1,0 +1,56 @@
+// Copyright 2017 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/storage"
+	"github.com/prometheus/prometheus/storage/tsdb"
+)
+
+// NewStorage returns a new storage for testing purposes
+// that removes all associated files on closing.
+func NewStorage(t T) storage.Storage {
+	dir, err := ioutil.TempDir("", "test_storage")
+	if err != nil {
+		t.Fatalf("Opening test dir failed: %s", err)
+	}
+
+	// Tests just load data for a series sequentially. Thus we
+	// need a long appendable window.
+	db, err := tsdb.Open(dir, nil, nil, &tsdb.Options{
+		MinBlockDuration: model.Duration(24 * time.Hour),
+		MaxBlockDuration: model.Duration(24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("Opening test storage failed: %s", err)
+	}
+	return testStorage{Storage: tsdb.Adapter(db, int64(0)), dir: dir}
+}
+
+type testStorage struct {
+	storage.Storage
+	dir string
+}
+
+func (s testStorage) Close() error {
+	if err := s.Storage.Close(); err != nil {
+		return err
+	}
+	return os.RemoveAll(s.dir)
+}

--- a/vendor/github.com/prometheus/prometheus/util/testutil/testing.go
+++ b/vendor/github.com/prometheus/prometheus/util/testutil/testing.go
@@ -1,0 +1,63 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2014 Ben Johnson
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package testutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Assert fails the test if the condition is false.
+func Assert(tb testing.TB, condition bool, format string, a ...interface{}) {
+	tb.Helper()
+	if !condition {
+		tb.Fatalf("\033[31m"+format+"\033[39m\n", a...)
+	}
+}
+
+// Ok fails the test if an err is not nil.
+func Ok(tb testing.TB, err error) {
+	tb.Helper()
+	if err != nil {
+		tb.Fatalf("\033[31munexpected error: %v\033[39m\n", err)
+	}
+}
+
+// NotOk fails the test if an err is nil.
+func NotOk(tb testing.TB, err error, format string, a ...interface{}) {
+	tb.Helper()
+	if err == nil {
+		if len(a) != 0 {
+			tb.Fatalf("\033[31m"+format+": expected error, got none\033[39m", a...)
+		}
+		tb.Fatalf("\033[31mexpected error, got none\033[39m")
+	}
+}
+
+// Equals fails the test if exp is not equal to act.
+func Equals(tb testing.TB, exp, act interface{}) {
+	tb.Helper()
+	if !reflect.DeepEqual(exp, act) {
+		tb.Fatalf("\033[31m\nexp: %#v\n\ngot: %#v\033[39m\n", exp, act)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -654,6 +654,18 @@
 			"revisionTime": "2017-01-17T20:06:51Z"
 		},
 		{
+			"checksumSHA1": "6EIQaeaWECn3zlechdGkqmIKld4=",
+			"path": "github.com/opentracing/opentracing-go",
+			"revision": "659c90643e714681897ec2521c60567dd21da733",
+			"revisionTime": "2019-03-23T20:25:03Z"
+		},
+		{
+			"checksumSHA1": "tnkdNJbJxNKuPZMWapP1xhKIIGw=",
+			"path": "github.com/opentracing/opentracing-go/log",
+			"revision": "659c90643e714681897ec2521c60567dd21da733",
+			"revisionTime": "2019-03-23T20:25:03Z"
+		},
+		{
 			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
 			"path": "github.com/pkg/errors",
 			"revision": "248dadf4e9068a0b3e79f02ed0a610d935de5302",
@@ -846,6 +858,12 @@
 			"revisionTime": "2018-06-05T10:30:19Z"
 		},
 		{
+			"checksumSHA1": "xqy3Mg4HizTrdtie9Ql7YlhBvCs=",
+			"path": "github.com/prometheus/prometheus/promql",
+			"revision": "057a5ae2b147b6a1dfe0d3a667e13ed6535dbe20",
+			"revisionTime": "2018-06-05T10:30:19Z"
+		},
+		{
 			"checksumSHA1": "+MySwSXOb6nwbb3tQi3GaVxDHbM=",
 			"path": "github.com/prometheus/prometheus/scrape",
 			"revision": "67dc912ac8b24f94a1fc478f352d25179c94ab9b",
@@ -858,9 +876,27 @@
 			"revisionTime": "2018-06-05T10:30:19Z"
 		},
 		{
+			"checksumSHA1": "ibW4coim9SvqJbFEcidzGOQ4sR0=",
+			"path": "github.com/prometheus/prometheus/storage/tsdb",
+			"revision": "057a5ae2b147b6a1dfe0d3a667e13ed6535dbe20",
+			"revisionTime": "2018-06-05T10:30:19Z"
+		},
+		{
+			"checksumSHA1": "tNz+YU7QG0xzETqtLOqClATw9IQ=",
+			"path": "github.com/prometheus/prometheus/util/stats",
+			"revision": "057a5ae2b147b6a1dfe0d3a667e13ed6535dbe20",
+			"revisionTime": "2018-06-05T10:30:19Z"
+		},
+		{
 			"checksumSHA1": "1Z1LToD/EEb1r+sWog8vtwfaGBk=",
 			"path": "github.com/prometheus/prometheus/util/strutil",
 			"revision": "ae96914199b4e1e47b27a3789c3044ee8a14e796",
+			"revisionTime": "2018-06-05T10:30:19Z"
+		},
+		{
+			"checksumSHA1": "H5Iboq7JzeHIxKpL8DYGNBitI1A=",
+			"path": "github.com/prometheus/prometheus/util/testutil",
+			"revision": "057a5ae2b147b6a1dfe0d3a667e13ed6535dbe20",
 			"revisionTime": "2018-06-05T10:30:19Z"
 		},
 		{


### PR DESCRIPTION
This allows specifying multiple sets of filters that time series will be
checked against. It also switches to using promql native parser for
filters.

Existing `--filter` flag will keep working, but is now marked as
deprecated.

This makes #106 obsolete.