### PR TITLE
Add a Counter Aggregator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ static_metadata:
 # - ...
 ```
 
+#### Counter Aggregator
+
+Counter Aggregator is an advanced feature of the sidecar that can be used to export a sum of multiple Prometheus counters to Stackdriver as a single CUMULATIVE metric.
+
+You might find this useful if you have counter metrics in Prometheus with high cardinality labels (or perhaps just counters exported by a large number of targets) which makes exporting all of them to Stackdriver directly too expensive, however you would like to have a cumulative metric that has the sum of those counters.
+
+Aggregated counters are configured in the `aggregated_counters` block of the configuration file. For example:
+
+```yaml
+aggregated_counters:
+  - metric: network_transmit_bytes
+    help: total number of bytes sent over eth0
+    filters:
+     - 'node_network_transmit_bytes_total{device="eth0"}'
+     - 'node_network_transmit_bytes{device="eth0"}'
+```
+
+In this example, the sidecar will export a new counter `network_transmit_bytes`, which will correspond to the total number of bytes transmitted over 'eth0' interface across all machines monitored by Prometheus. Counter Aggregator keeps track of all counters matching the filters and correctly handles counter resets. Like all internal metrics exported by the sidecar, the aggregated counter is exported using OpenCensus and will be available in Stackdriver as a custom metric (`custom.googleapis.com/opencensus/prometheus_sidecar/aggregated_counters/network_transmit_bytes`).
+
+Please note that by default metrics that match one of aggregated counter filters will still be exported to Stackdriver unless you have inclusion filters configured that prevent those metrics from being exported (see `--include`). When using Counter Aggregator you would usually want to configure a restrictive inclusion filter to avoid raw metrics from being exported to Stackdriver.
+
+For aggregated metrics to be exported to Stackdriver you will also need to enable Stackdriver monitoring backend in the sidecar by passing `--monitoring.backend=stackdriver` flag (please also pass `--monitoring.backend=prometheus` if you are collecting sidecar metrics to Prometheus).
+
 ## Compatibility
 
 The matrix below lists the versions of Prometheus Server and other dependencies that have been qualified to work with releases of `stackdriver-prometheus-sidecar`.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This drops all series which do not have a `job` label `k8s` and all metrics that
 
 For equality filter on metric name you can use the simpler notation, e.g. `--include='metric_name{label="foo"}'`.
 
-The flag may be repeated to provide several sets of filters, in which case the metric will be forwarded if it matches at least one of them.
+The flag may be repeated to provide several sets of filters, in which case the metric will be forwarded if it matches at least one of them. Please note that inclusion filters only apply to Prometheus metrics prixied directly, and do not apply to [aggregated counters](#counter-aggregator).
 
 #### File
 
@@ -96,9 +96,13 @@ aggregated_counters:
 
 In this example, the sidecar will export a new counter `network_transmit_bytes`, which will correspond to the total number of bytes transmitted over 'eth0' interface across all machines monitored by Prometheus. Counter Aggregator keeps track of all counters matching the filters and correctly handles counter resets. Like all internal metrics exported by the sidecar, the aggregated counter is exported using OpenCensus and will be available in Stackdriver as a custom metric (`custom.googleapis.com/opencensus/prometheus_sidecar/aggregated_counters/network_transmit_bytes`).
 
-Please note that by default metrics that match one of aggregated counter filters will still be exported to Stackdriver unless you have inclusion filters configured that prevent those metrics from being exported (see `--include`). When using Counter Aggregator you would usually want to configure a restrictive inclusion filter to avoid raw metrics from being exported to Stackdriver.
-
 For aggregated metrics to be exported to Stackdriver you will also need to enable Stackdriver monitoring backend in the sidecar by passing `--monitoring.backend=stackdriver` flag (please also pass `--monitoring.backend=prometheus` if you are collecting sidecar metrics to Prometheus).
+
+##### Counter aggregator and inclusion filters
+
+Please note that by default metrics that match one of aggregated counter filters will still be exported to Stackdriver unless you have inclusion filters configured that prevent those metrics from being exported (see `--include`). Using `--include` to prevent a metric from being exported to Stackdriver does not prevent the metric from being covered by aggregated counters.
+
+When using Counter Aggregator you would usually want to configure a restrictive inclusion filter to avoid raw metrics from being exported to Stackdriver.
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This drops all series which do not have a `job` label `k8s` and all metrics that
 
 For equality filter on metric name you can use the simpler notation, e.g. `--include='metric_name{label="foo"}'`.
 
-The flag may be repeated to provide several sets of filters, in which case the metric will be forwarded if it matches at least one of them. Please note that inclusion filters only apply to Prometheus metrics prixied directly, and do not apply to [aggregated counters](#counter-aggregator).
+The flag may be repeated to provide several sets of filters, in which case the metric will be forwarded if it matches at least one of them. Please note that inclusion filters only apply to Prometheus metrics proxied directly, and do not apply to [aggregated counters](#counter-aggregator).
 
 #### File
 
@@ -94,7 +94,9 @@ aggregated_counters:
      - 'node_network_transmit_bytes{device="eth0"}'
 ```
 
-In this example, the sidecar will export a new counter `network_transmit_bytes`, which will correspond to the total number of bytes transmitted over 'eth0' interface across all machines monitored by Prometheus. Counter Aggregator keeps track of all counters matching the filters and correctly handles counter resets. Like all internal metrics exported by the sidecar, the aggregated counter is exported using OpenCensus and will be available in Stackdriver as a custom metric (`custom.googleapis.com/opencensus/prometheus_sidecar/aggregated_counters/network_transmit_bytes`).
+In this example, the sidecar will export a new counter `network_transmit_bytes`, which will correspond to the total number of bytes transmitted over 'eth0' interface across all machines monitored by Prometheus. Counter Aggregator keeps track of all counters matching the filters and correctly handles counter resets. Like all internal metrics exported by the sidecar, the aggregated counter is exported using OpenCensus and will be available in Stackdriver as a custom metric (`custom.googleapis.com/opencensus/network_transmit_bytes`).
+
+A list of [Prometheus instant vector selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) is expected in the `filters` field. A time series needs to match any of the specified selectors to be included in the aggregated counter.
 
 For aggregated metrics to be exported to Stackdriver you will also need to enable Stackdriver monitoring backend in the sidecar by passing `--monitoring.backend=stackdriver` flag (please also pass `--monitoring.backend=prometheus` if you are collecting sidecar metrics to Prometheus).
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,6 @@ In this example, the sidecar will export a new counter `network_transmit_bytes`,
 
 A list of [Prometheus instant vector selectors](https://prometheus.io/docs/prometheus/latest/querying/basics/#instant-vector-selectors) is expected in the `filters` field. A time series needs to match any of the specified selectors to be included in the aggregated counter.
 
-For aggregated metrics to be exported to Stackdriver you will also need to enable Stackdriver monitoring backend in the sidecar by passing `--monitoring.backend=stackdriver` flag (please also pass `--monitoring.backend=prometheus` if you are collecting sidecar metrics to Prometheus).
-
 ##### Counter aggregator and inclusion filters
 
 Please note that by default metrics that match one of aggregated counter filters will still be exported to Stackdriver unless you have inclusion filters configured that prevent those metrics from being exported (see `--include`). Using `--include` to prevent a metric from being exported to Stackdriver does not prevent the metric from being covered by aggregated counters.

--- a/cmd/stackdriver-prometheus-sidecar/main.go
+++ b/cmd/stackdriver-prometheus-sidecar/main.go
@@ -267,6 +267,19 @@ func main() {
 			level.Error(logger).Log("msg", msg, "err", err)
 			os.Exit(2)
 		}
+
+		// Enable Stackdriver monitoring backend if counter aggregator configuration is present.
+		if len(cfg.aggregations) > 0 {
+			sdEnabled := false
+			for _, backend := range cfg.monitoringBackends {
+				if backend == "stackdriver" {
+					sdEnabled = true
+				}
+			}
+			if !sdEnabled {
+				cfg.monitoringBackends = append(cfg.monitoringBackends, "stackdriver")
+			}
+		}
 	}
 
 	level.Info(logger).Log("msg", "Starting Stackdriver Prometheus sidecar", "version", version.Info())

--- a/cmd/stackdriver-prometheus-sidecar/main.go
+++ b/cmd/stackdriver-prometheus-sidecar/main.go
@@ -667,11 +667,11 @@ func parseConfigFile(filename string) (map[string]string, []scrape.MetricMetadat
 		}
 		a := &retrieval.CounterAggregatorMetricConfig{Help: c.Help}
 		for _, f := range c.Filters {
-			matchers, err := promql.ParseMetricSelector(f)
+			matcher, err := promql.ParseMetricSelector(f)
 			if err != nil {
 				return nil, nil, nil, errors.Errorf("cannot parse metric selector '%s': %q", f, err)
 			}
-			a.Matchers = append(a.Matchers, matchers)
+			a.Matchers = append(a.Matchers, matcher)
 		}
 		aggregations[c.Metric] = a
 	}

--- a/retrieval/aggregator.go
+++ b/retrieval/aggregator.go
@@ -1,0 +1,158 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retrieval
+
+import (
+	"context"
+	"math"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	promlabels "github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/tsdb/labels"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var statsRecord = stats.Record
+
+const metricPrefix = "prometheus_sidecar/aggregated_counters/"
+
+// CounterAggregator provides the 'aggregated counters' feature of the sidecar.
+// It can be used to export a sum of multiple counters from Prometheus to
+// Stackdriver as a single cumulative metric.
+type CounterAggregator struct {
+	logger   log.Logger
+	counters []*aggregatedCounter
+}
+
+// aggregatedCounter is where CounterAggregator keeps internal state about each
+// exported metric: OpenCensus measure and view as well as a list of Matchers that
+// define which Prometheus metrics will get aggregated.
+type aggregatedCounter struct {
+	measure  *stats.Float64Measure
+	view     *view.View
+	matchers [][]*promlabels.Matcher
+}
+
+// CounterAggregatorConfig contains configuration for CounterAggregator. Keys of the map
+// are metric names that will be exported by counter aggregator.
+type CounterAggregatorConfig map[string]*CounterAggregatorMetricConfig
+
+// CounterAggregatorMetricConfig provides configuration of a single aggregated counter.
+// Matchers specify what Prometheus metrics (which are expected to be counter metrics) will
+// be re-aggregated. Help provides a description for the exported metric.
+type CounterAggregatorMetricConfig struct {
+	Matchers [][]*promlabels.Matcher
+	Help     string
+}
+
+// counterTracker keeps track of a single time series that has at least one aggregated
+// counter associated with it (i.e. there is at least one aggregated counter that has
+// Matchers covering this time series). Last timestamp and value are tracked
+// to detect counter resets.
+type counterTracker struct {
+	lastTimestamp int64
+	lastValue     float64
+	measures      []*stats.Float64Measure
+	logger        log.Logger
+}
+
+// NewCounterAggregator creates a counter aggregator.
+func NewCounterAggregator(logger log.Logger, config *CounterAggregatorConfig) (*CounterAggregator, error) {
+	aggregator := &CounterAggregator{logger: logger}
+	for metric, cfg := range *config {
+		name := metricPrefix + metric
+		measure := stats.Float64(name, cfg.Help, stats.UnitDimensionless)
+		v := &view.View{
+			Name:        name,
+			Description: cfg.Help,
+			Measure:     measure,
+			Aggregation: view.Sum(),
+		}
+		if err := view.Register(v); err != nil {
+			return nil, err
+		}
+		aggregator.counters = append(aggregator.counters, &aggregatedCounter{
+			measure:  measure,
+			view:     v,
+			matchers: cfg.Matchers,
+		})
+	}
+	return aggregator, nil
+}
+
+// Close must be called when CounterAggregator is no longer needed.
+func (c *CounterAggregator) Close() {
+	for _, counter := range c.counters {
+		view.Unregister(counter.view)
+	}
+}
+
+// getTracker returns a counterTracker for a specific time series defined by labelset.
+// If `nil` is returned, it means that there are no aggregated counters that need to
+// be incremented for this time series.
+func (c *CounterAggregator) getTracker(lset labels.Labels) *counterTracker {
+	var measures []*stats.Float64Measure
+	for _, counter := range c.counters {
+		if matchFiltersets(lset, counter.matchers) {
+			measures = append(measures, counter.measure)
+		}
+	}
+	if len(measures) == 0 {
+		return nil
+	}
+	return &counterTracker{measures: measures, logger: c.logger}
+}
+
+// newPoint gets called on each new sample (timestamp, value) for time series that need to feed
+// values into aggregated counters.
+func (a *counterTracker) newPoint(ctx context.Context, lset labels.Labels, t int64, v float64) {
+	if math.IsNaN(v) {
+		level.Debug(a.logger).Log("msg", "got NaN value", "labels", lset, "last ts", a.lastTimestamp, "ts", t, "lastValue", a.lastValue)
+		return
+	}
+	// Ignore points that are earlier than last seen timestamp.
+	if t < a.lastTimestamp {
+		level.Debug(a.logger).Log("msg", "out of order timestamp", "labels", lset, "last ts", a.lastTimestamp, "ts", t)
+		return
+	}
+	// First time we're seeing a value; record it, but don't increment counters.
+	if a.lastTimestamp == 0 {
+		level.Debug(a.logger).Log("msg", "first point", "labels", lset)
+		a.lastTimestamp = t
+		a.lastValue = v
+		return
+	}
+	var delta float64
+	if v < a.lastValue {
+		// Counter was reset.
+		delta = v
+		level.Debug(a.logger).Log("msg", "counter reset", "labels", lset, "value", v, "lastValue", a.lastValue, "delta", delta)
+	} else {
+		delta = v - a.lastValue
+		level.Debug(a.logger).Log("msg", "got delta", "labels", lset, "value", v, "lastValue", a.lastValue, "delta", delta)
+	}
+	a.lastTimestamp = t
+	a.lastValue = v
+	if delta == 0 {
+		return
+	}
+	ms := make([]stats.Measurement, len(a.measures))
+	for i, measure := range a.measures {
+		ms[i] = measure.M(delta)
+	}
+	statsRecord(ctx, ms...)
+}

--- a/retrieval/aggregator_test.go
+++ b/retrieval/aggregator_test.go
@@ -55,20 +55,19 @@ func TestCounterAggregator(t *testing.T) {
 			}()
 			logger := log.NewLogfmtLogger(logBuffer)
 
-			var got []float64
-			statsRecord = func(ctx context.Context, ms ...stats.Measurement) {
-				for _, m := range ms {
-					got = append(got, m.Value())
-				}
-			}
-			defer func() { statsRecord = stats.Record }()
-
 			aggr, _ := NewCounterAggregator(logger, &CounterAggregatorConfig{
 				"counter1": &CounterAggregatorMetricConfig{Matchers: [][]*promlabels.Matcher{
 					{&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "a", Value: "a1"}},
 				}},
 			})
 			defer aggr.Close()
+
+			var got []float64
+			aggr.statsRecord = func(ctx context.Context, ms ...stats.Measurement) {
+				for _, m := range ms {
+					got = append(got, m.Value())
+				}
+			}
 
 			lset := labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a1")
 			tracker := aggr.getTracker(lset)

--- a/retrieval/aggregator_test.go
+++ b/retrieval/aggregator_test.go
@@ -1,0 +1,84 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retrieval
+
+import (
+	"bytes"
+	"context"
+	"math"
+	"reflect"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	promlabels "github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/tsdb/labels"
+	"go.opencensus.io/stats"
+)
+
+func TestCounterAggregator(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	type input struct {
+		ts    int64
+		value float64
+	}
+
+	for _, tt := range []struct {
+		name  string
+		input []input
+		want  []float64
+	}{
+		{"simple", []input{input{1, 15}, input{2, 25}}, []float64{10}},
+		{"counter resets", []input{input{1, 15}, input{2, 25}, input{3, 5}, input{4, 25}, input{5, 15}}, []float64{10, 5, 20, 15}},
+		{"NaNs are ignored", []input{input{1, 15}, input{2, math.NaN()}, input{3, 25}}, []float64{10}},
+		{"out of order points are ignored", []input{input{1, 15}, input{3, 25}, {2, 20}, {4, 30}}, []float64{10, 5}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			logBuffer := &bytes.Buffer{}
+			defer func() {
+				if logBuffer.Len() > 0 {
+					t.Log(logBuffer.String())
+				}
+			}()
+			logger := log.NewLogfmtLogger(logBuffer)
+
+			var got []float64
+			statsRecord = func(ctx context.Context, ms ...stats.Measurement) {
+				for _, m := range ms {
+					got = append(got, m.Value())
+				}
+			}
+			defer func() { statsRecord = stats.Record }()
+
+			aggr, _ := NewCounterAggregator(logger, &CounterAggregatorConfig{
+				"counter1": &CounterAggregatorMetricConfig{Matchers: [][]*promlabels.Matcher{
+					{&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "a", Value: "a1"}},
+				}},
+			})
+			defer aggr.Close()
+
+			lset := labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a1")
+			tracker := aggr.getTracker(lset)
+
+			for _, input := range tt.input {
+				tracker.newPoint(ctx, lset, input.ts, input.value)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("unexpected values %v; want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -87,6 +87,7 @@ func NewPrometheusReader(
 	appender Appender,
 	metricsPrefix string,
 	useGkeResource bool,
+	counterAggregator *CounterAggregator,
 ) *PrometheusReader {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -103,6 +104,7 @@ func NewPrometheusReader(
 		metricRenames:        metricRenames,
 		metricsPrefix:        metricsPrefix,
 		useGkeResource:       useGkeResource,
+		counterAggregator:    counterAggregator,
 	}
 }
 
@@ -118,6 +120,7 @@ type PrometheusReader struct {
 	progressSaveInterval time.Duration
 	metricsPrefix        string
 	useGkeResource       bool
+	counterAggregator    *CounterAggregator
 }
 
 var (
@@ -159,6 +162,7 @@ func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 		ResourceMappings,
 		r.metricsPrefix,
 		r.useGkeResource,
+		r.counterAggregator,
 	)
 	go seriesCache.run(ctx)
 

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/Stackdriver/stackdriver-prometheus-sidecar/tail"
 	"github.com/Stackdriver/stackdriver-prometheus-sidecar/targets"
+	"github.com/go-kit/kit/log"
 	promlabels "github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
 	"github.com/prometheus/prometheus/scrape"
@@ -84,7 +85,8 @@ func TestReader_Progress(t *testing.T) {
 		"job1/inst1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
 	}
 
-	r := NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, &nopAppender{}, "", false)
+	aggr, _ := NewCounterAggregator(log.NewNopLogger(), new(CounterAggregatorConfig))
+	r := NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, &nopAppender{}, "", false, aggr)
 	r.progressSaveInterval = 200 * time.Millisecond
 
 	// Populate sample data
@@ -141,7 +143,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	recorder := &nopAppender{}
-	r = NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, recorder, "", false)
+	r = NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, recorder, "", false, aggr)
 	go r.Run(ctx, progressOffset)
 
 	// Wait for reader to process until the end.

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -315,10 +315,7 @@ func (c *seriesCache) getResetAdjusted(ref uint64, t int64, v float64) (int64, f
 // set the label set for the given reference.
 // maxSegment indicates the the highest segment at which the series was possibly defined.
 func (c *seriesCache) set(ctx context.Context, ref uint64, lset labels.Labels, maxSegment int) error {
-	exported := false
-	if c.filtersets == nil || matchFiltersets(lset, c.filtersets) {
-		exported = true
-	}
+	exported := c.filtersets == nil || matchFiltersets(lset, c.filtersets)
 	counterTracker := c.counterAggregator.getTracker(lset)
 
 	if !exported && counterTracker == nil {

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -54,13 +54,14 @@ func TestScrapeCache_GarbageCollect(t *testing.T) {
 		}
 	}()
 	logger := log.NewLogfmtLogger(logBuffer)
+	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
 	c := newSeriesCache(logger, dir, nil, nil,
 		targetMap{"/": &targets.Target{}},
 		metadataMap{"//": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge}},
 		[]ResourceMap{
 			{Type: "resource1", LabelMap: map[string]labelTranslation{}},
 		},
-		"", false,
+		"", false, aggr,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -200,7 +201,8 @@ func TestSeriesCache_Refresh(t *testing.T) {
 		}
 	}()
 	logger := log.NewLogfmtLogger(logBuffer)
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false)
+	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -247,6 +249,9 @@ func TestSeriesCache_Refresh(t *testing.T) {
 	if entry == nil || !ok || err != nil {
 		t.Errorf("expected metadata but got none, error: %s", err)
 	}
+	if entry.exported != true {
+		t.Errorf("expected to get exported entry")
+	}
 }
 
 func TestSeriesCache_RefreshTooManyLabels(t *testing.T) {
@@ -272,7 +277,8 @@ func TestSeriesCache_RefreshTooManyLabels(t *testing.T) {
 	metadataMap := metadataMap{
 		"job1/inst1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
 	}
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false)
+	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -323,7 +329,8 @@ func TestSeriesCache_RefreshUnknownResource(t *testing.T) {
 	metadataMap := metadataMap{
 		"job1/inst1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
 	}
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false)
+	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -368,7 +375,8 @@ func TestSeriesCache_RefreshMetadataNotFound(t *testing.T) {
 		},
 	}
 	metadataMap := metadataMap{}
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false)
+	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -416,13 +424,14 @@ func TestSeriesCache_Filter(t *testing.T) {
 		}
 	}()
 	logger := log.NewLogfmtLogger(logBuffer)
+	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
 	c := newSeriesCache(logger, "", [][]*promlabels.Matcher{
 		{
 			&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "a", Value: "a1"},
 			&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "b", Value: "b1"},
 		},
 		{&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "c", Value: "c1"}},
-	}, nil, targetMap, metadataMap, resourceMaps, "", false)
+	}, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -453,6 +462,75 @@ func TestSeriesCache_Filter(t *testing.T) {
 	}
 }
 
+func TestSeriesCache_CounterAggregator(t *testing.T) {
+	resourceMaps := []ResourceMap{
+		{
+			Type:     "resource2",
+			LabelMap: map[string]labelTranslation{"__resource_a": constValue("resource_a")},
+		},
+	}
+	// Populate the getters with data.
+	targetMap := targetMap{
+		"job1/inst1": &targets.Target{
+			Labels:           promlabels.FromStrings("job", "job1", "instance", "inst1"),
+			DiscoveredLabels: promlabels.FromStrings("__resource_a", "resource2_a"),
+		},
+	}
+	metadataMap := metadataMap{
+		"job1/inst1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
+	}
+	logger := log.NewNopLogger()
+	aggr, _ := NewCounterAggregator(logger, &CounterAggregatorConfig{
+		"counter1": &CounterAggregatorMetricConfig{Matchers: [][]*promlabels.Matcher{
+			{&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "a", Value: "a1"}},
+		}},
+	})
+	c := newSeriesCache(logger, "", [][]*promlabels.Matcher{
+		{&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "b", Value: "b1"}},
+	}, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for idx, tt := range []struct {
+		name         string
+		lset         labels.Labels
+		wantExported bool
+		wantTracked  bool
+	}{
+		{"exported and tracked", labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a1", "b", "b1"), true, true},
+		{"exported", labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a2", "b", "b1"), true, false},
+		{"tracked", labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a1", "b", "b2"), false, true},
+		{"unexported and untracked", labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "c", "c1"), false, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := c.set(ctx, uint64(idx), tt.lset, 1)
+			if err != nil {
+				t.Fatal(err)
+			}
+			entry, ok, err := c.get(ctx, uint64(idx))
+			if err != nil {
+				t.Fatalf("unexpected error: %s", err)
+			}
+			if !ok {
+				if tt.wantExported || tt.wantTracked {
+					t.Error("expected entry to exist, but it does not")
+				}
+			} else {
+				if !tt.wantExported && !tt.wantTracked {
+					t.Errorf("did not expect entry to exist: %v", tt)
+				}
+				if tt.wantExported != entry.exported {
+					t.Errorf("unexpected value of exported: %v; want %v", entry.exported, tt.wantExported)
+				}
+				if tt.wantTracked != (entry.tracker != nil) {
+					t.Errorf("unexpected value of tracker: %v; want %v", entry.tracker, tt.wantTracked)
+				}
+			}
+		})
+	}
+}
+
 func TestSeriesCache_RenameMetric(t *testing.T) {
 	resourceMaps := []ResourceMap{
 		{
@@ -478,9 +556,10 @@ func TestSeriesCache_RenameMetric(t *testing.T) {
 		}
 	}()
 	logger := log.NewLogfmtLogger(logBuffer)
+	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
 	c := newSeriesCache(logger, "", nil,
 		map[string]string{"metric2": "metric3"},
-		targetMap, metadataMap, resourceMaps, "", false)
+		targetMap, metadataMap, resourceMaps, "", false, aggr)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -249,7 +249,7 @@ func TestSeriesCache_Refresh(t *testing.T) {
 	if entry == nil || !ok || err != nil {
 		t.Errorf("expected metadata but got none, error: %s", err)
 	}
-	if entry.exported != true {
+	if !entry.exported {
 		t.Errorf("expected to get exported entry")
 	}
 }
@@ -495,8 +495,8 @@ func TestSeriesCache_CounterAggregator(t *testing.T) {
 	for idx, tt := range []struct {
 		name         string
 		lset         labels.Labels
-		wantExported bool
-		wantTracked  bool
+		wantExported bool // Metric is expected to be exported to Stackdriver.
+		wantTracked  bool // Metric is included in one of the aggregated counters, and should have non-nil counter tracker.
 	}{
 		{"exported and tracked", labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a1", "b", "b1"), true, true},
 		{"exported", labels.FromStrings("__name__", "metric1", "job", "job1", "instance", "inst1", "a", "a2", "b", "b1"), true, false},

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -46,6 +46,14 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*mo
 	if !ok {
 		return nil, 0, samples[1:], nil
 	}
+
+	if entry.tracker != nil {
+		entry.tracker.newPoint(ctx, entry.lset, sample.T, sample.V)
+	}
+
+	if !entry.exported {
+		return nil, 0, samples[1:], nil
+	}
 	// Get a shallow copy of the proto so we can overwrite the point field
 	// and safely send it into the remote queues.
 	ts := *entry.proto

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/Stackdriver/stackdriver-prometheus-sidecar/targets"
+	"github.com/go-kit/kit/log"
 	timestamp_pb "github.com/golang/protobuf/ptypes/timestamp"
 	promlabels "github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/pkg/textparse"
@@ -636,7 +637,8 @@ func TestSampleBuilder(t *testing.T) {
 		var err error
 		var result []*monitoring_pb.TimeSeries
 
-		series := newSeriesCache(nil, "", nil, nil, c.targets, c.metadata, resourceMaps, c.metricPrefix, false)
+		aggr, _ := NewCounterAggregator(log.NewNopLogger(), new(CounterAggregatorConfig))
+		series := newSeriesCache(nil, "", nil, nil, c.targets, c.metadata, resourceMaps, c.metricPrefix, false, aggr)
 		for ref, s := range c.series {
 			series.set(ctx, ref, s, 0)
 		}


### PR DESCRIPTION
Counter Aggregator allows exporting a sum of multiple Prometheus counters to Stackdriver as a single CUMULATIVE metric.

This can be useful if you have so many counter metrics (or metrics with high label cardinality) in Prometheus that importing all of them to Stackdriver directly might be too expensive, however you would like to have a total cumulative counter that corresponds to the sum of those counters.
