### PR TITLE
Improve debug logging when resource name cannot be detected.

### DIFF
--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -377,7 +377,7 @@ func (c *seriesCache) refresh(ctx context.Context, ref uint64) error {
 	if !ok {
 		ctx, _ = tag.New(ctx, tag.Insert(keyReason, "unknown_resource"))
 		stats.Record(ctx, droppedSeries.M(1))
-		level.Debug(c.logger).Log("msg", "unknown resource", "labels", target.Labels)
+		level.Debug(c.logger).Log("msg", "unknown resource", "labels", target.Labels, "discovered_labels", target.DiscoveredLabels)
 		return nil
 	}
 	var (


### PR DESCRIPTION
This expands log message with discovered labels as well, which makes
debugging 'unknown_resource' errors easier.