### PR TITLE
Filter prometheus metric labels

### DIFF
--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -88,6 +88,7 @@ func NewPrometheusReader(
 	metricsPrefix string,
 	useGkeResource bool,
 	counterAggregator *CounterAggregator,
+	dropLabels map[string]string,
 ) *PrometheusReader {
 	if logger == nil {
 		logger = log.NewNopLogger()
@@ -105,6 +106,7 @@ func NewPrometheusReader(
 		metricsPrefix:        metricsPrefix,
 		useGkeResource:       useGkeResource,
 		counterAggregator:    counterAggregator,
+		dropLabels:           dropLabels,
 	}
 }
 
@@ -121,6 +123,7 @@ type PrometheusReader struct {
 	metricsPrefix        string
 	useGkeResource       bool
 	counterAggregator    *CounterAggregator
+	dropLabels           map[string]string
 }
 
 var (
@@ -163,6 +166,7 @@ func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 		r.metricsPrefix,
 		r.useGkeResource,
 		r.counterAggregator,
+		r.dropLabels,
 	)
 	go seriesCache.run(ctx)
 

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -39,6 +39,10 @@ type nopAppender struct {
 	samples []*monitoring_pb.TimeSeries
 }
 
+var (
+	dropLabels map[string]string
+)
+
 func (a *nopAppender) Append(hash uint64, s *monitoring_pb.TimeSeries) error {
 	a.samples = append(a.samples, s)
 	return nil
@@ -86,7 +90,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	aggr, _ := NewCounterAggregator(log.NewNopLogger(), new(CounterAggregatorConfig))
-	r := NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, &nopAppender{}, "", false, aggr)
+	r := NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, &nopAppender{}, "", false, aggr, dropLabels)
 	r.progressSaveInterval = 200 * time.Millisecond
 
 	// Populate sample data
@@ -143,7 +147,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	recorder := &nopAppender{}
-	r = NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, recorder, "", false, aggr)
+	r = NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, recorder, "", false, aggr, dropLabels)
 	go r.Run(ctx, progressOffset)
 
 	// Wait for reader to process until the end.

--- a/retrieval/series_cache_test.go
+++ b/retrieval/series_cache_test.go
@@ -61,7 +61,7 @@ func TestScrapeCache_GarbageCollect(t *testing.T) {
 		[]ResourceMap{
 			{Type: "resource1", LabelMap: map[string]labelTranslation{}},
 		},
-		"", false, aggr,
+		"", false, aggr, dropLabels,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -202,7 +202,7 @@ func TestSeriesCache_Refresh(t *testing.T) {
 	}()
 	logger := log.NewLogfmtLogger(logBuffer)
 	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr, dropLabels)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -278,7 +278,7 @@ func TestSeriesCache_RefreshTooManyLabels(t *testing.T) {
 		"job1/inst1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
 	}
 	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr, dropLabels)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -330,7 +330,7 @@ func TestSeriesCache_RefreshUnknownResource(t *testing.T) {
 		"job1/inst1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
 	}
 	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr, dropLabels)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -376,7 +376,7 @@ func TestSeriesCache_RefreshMetadataNotFound(t *testing.T) {
 	}
 	metadataMap := metadataMap{}
 	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
-	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
+	c := newSeriesCache(logger, "", nil, nil, targetMap, metadataMap, resourceMaps, "", false, aggr, dropLabels)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -431,7 +431,7 @@ func TestSeriesCache_Filter(t *testing.T) {
 			&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "b", Value: "b1"},
 		},
 		{&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "c", Value: "c1"}},
-	}, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
+	}, nil, targetMap, metadataMap, resourceMaps, "", false, aggr, dropLabels)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -487,7 +487,7 @@ func TestSeriesCache_CounterAggregator(t *testing.T) {
 	})
 	c := newSeriesCache(logger, "", [][]*promlabels.Matcher{
 		{&promlabels.Matcher{Type: promlabels.MatchEqual, Name: "b", Value: "b1"}},
-	}, nil, targetMap, metadataMap, resourceMaps, "", false, aggr)
+	}, nil, targetMap, metadataMap, resourceMaps, "", false, aggr, dropLabels)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -559,7 +559,7 @@ func TestSeriesCache_RenameMetric(t *testing.T) {
 	aggr, _ := NewCounterAggregator(logger, new(CounterAggregatorConfig))
 	c := newSeriesCache(logger, "", nil,
 		map[string]string{"metric2": "metric3"},
-		targetMap, metadataMap, resourceMaps, "", false, aggr)
+		targetMap, metadataMap, resourceMaps, "", false, aggr, dropLabels)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -638,7 +638,7 @@ func TestSampleBuilder(t *testing.T) {
 		var result []*monitoring_pb.TimeSeries
 
 		aggr, _ := NewCounterAggregator(log.NewNopLogger(), new(CounterAggregatorConfig))
-		series := newSeriesCache(nil, "", nil, nil, c.targets, c.metadata, resourceMaps, c.metricPrefix, false, aggr)
+		series := newSeriesCache(nil, "", nil, nil, c.targets, c.metadata, resourceMaps, c.metricPrefix, false, aggr, dropLabels)
 		for ref, s := range c.series {
 			series.set(ctx, ref, s, 0)
 		}

--- a/stackdriver/client_test.go
+++ b/stackdriver/client_test.go
@@ -163,9 +163,9 @@ func TestResolver(t *testing.T) {
 			t.Fatal(err)
 		}
 		requestedTarget := c.conn.Target()
-		expectedTarget := c.resolver.Scheme()+":///" + address
+		expectedTarget := c.resolver.Scheme() + ":///" + address
 		if requestedTarget != expectedTarget {
-			t.Errorf("ERROR: Remote address is %s, want " + expectedTarget,
+			t.Errorf("ERROR: Remote address is %s, want "+expectedTarget,
 				requestedTarget)
 		}
 	}

--- a/targets/cache.go
+++ b/targets/cache.go
@@ -203,7 +203,7 @@ type Target struct {
 }
 
 // DropTargetLabels drops labels from the series that are found in the target with
-// exact name/value matches.
+// exact name/value matches
 func DropTargetLabels(series, target labels.Labels) labels.Labels {
 	repl := series[:0]
 	for _, l := range series {


### PR DESCRIPTION
Stackdriver has a hard quota of 10 labels per external metric, but
prometheus metrics may have an arbitrary number of labels.

Add a `--droplabel` flag (repeatable) to assemble a list of
prometheus labels to never forward to stackdriver.