### PR TITLE
Scope down time sensitive code.

### DIFF
--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -92,6 +92,9 @@ func TestTailFuzz(t *testing.T) {
 		time.Sleep(time.Second)
 		cancel()
 	}()
+	// It's safe to call Next() again. The last invocation must have returned `true`,
+	// or else the comparison between `read` and `written` above will fail and cause
+	// the test to end early.
 	if wr.Next() {
 		t.Fatal("read unexpected record")
 	}

--- a/tail/tail_test.go
+++ b/tail/tail_test.go
@@ -65,13 +65,13 @@ func TestTailFuzz(t *testing.T) {
 			}
 			written = append(written, rec)
 		}
-		time.Sleep(time.Second)
-		cancel()
 	}()
 
 	wr := wal.NewReader(rc)
 
-	for wr.Next() {
+	// Expect `count` records; read them all, if possible. The test will
+	// time out if fewer records show up.
+	for len(read) < count && wr.Next() {
 		read = append(read, append([]byte(nil), wr.Record()...))
 	}
 	if wr.Err() != nil {
@@ -84,6 +84,19 @@ func TestTailFuzz(t *testing.T) {
 		if !bytes.Equal(r, written[i]) {
 			t.Fatalf("record %d doesn't match", i)
 		}
+	}
+	// Attempt to read one more record, but expect no more records.
+	// Give the reader a chance to run for a while, then cancel its
+	// context so the test doesn't time out.
+	go func() {
+		time.Sleep(time.Second)
+		cancel()
+	}()
+	if wr.Next() {
+		t.Fatal("read unexpected record")
+	}
+	if wr.Err() != nil {
+		t.Fatal(wr.Err())
 	}
 }
 


### PR DESCRIPTION
The intention is to reduce flakes in this test. The test now will block until the 50,000 expected records are processed. Then it will wait for a second for potential extra records; because none are expected, there should be on flakes when the code is operating correctly.

Fixes #67 