### PR TITLE
Support metrics with the _total suffix and treat them as counters.

### DIFF
--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -391,8 +391,8 @@ func (c *seriesCache) refresh(ctx context.Context, ref uint64) error {
 		return errors.Wrap(err, "get metadata")
 	}
 	if metadata == nil {
-		// The full name didn't turn anything up. Check again in case it's a summary or histogram without
-		// the metric name suffix.
+		// The full name didn't turn anything up. Check again in case it's a summary,
+		// histogram, or counter without the metric name suffix.
 		var ok bool
 		if baseMetricName, suffix, ok = stripComplexMetricSuffix(metricName); ok {
 			metadata, err = c.metadata.Get(ctx, job, instance, baseMetricName)

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -380,12 +380,11 @@ func (c *seriesCache) refresh(ctx context.Context, ref uint64) error {
 		return nil
 	}
 	var (
-		metricName        = entry.lset.Get("__name__")
-		baseMetricName    string
-		suffix            string
-		useBaseMetricName bool
-		job               = entry.lset.Get("job")
-		instance          = entry.lset.Get("instance")
+		metricName     = entry.lset.Get("__name__")
+		baseMetricName string
+		suffix         string
+		job            = entry.lset.Get("job")
+		instance       = entry.lset.Get("instance")
 	)
 	metadata, err := c.metadata.Get(ctx, job, instance, metricName)
 	if err != nil {
@@ -394,7 +393,7 @@ func (c *seriesCache) refresh(ctx context.Context, ref uint64) error {
 	if metadata == nil {
 		// The full name didn't turn anything up. Check again in case it's a summary or histogram without
 		// the metric name suffix.
-		var ok bool
+		var useBaseMetricName, ok bool
 		if baseMetricName, suffix, useBaseMetricName, ok = stripComplexMetricSuffix(metricName); ok {
 			metadata, err = c.metadata.Get(ctx, job, instance, baseMetricName)
 			if err != nil {

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -380,11 +380,12 @@ func (c *seriesCache) refresh(ctx context.Context, ref uint64) error {
 		return nil
 	}
 	var (
-		metricName     = entry.lset.Get("__name__")
-		baseMetricName string
-		suffix         string
-		job            = entry.lset.Get("job")
-		instance       = entry.lset.Get("instance")
+		metricName        = entry.lset.Get("__name__")
+		baseMetricName    string
+		suffix            string
+		useBaseMetricName bool
+		job               = entry.lset.Get("job")
+		instance          = entry.lset.Get("instance")
 	)
 	metadata, err := c.metadata.Get(ctx, job, instance, metricName)
 	if err != nil {
@@ -394,10 +395,13 @@ func (c *seriesCache) refresh(ctx context.Context, ref uint64) error {
 		// The full name didn't turn anything up. Check again in case it's a summary or histogram without
 		// the metric name suffix.
 		var ok bool
-		if baseMetricName, suffix, ok = stripComplexMetricSuffix(metricName); ok {
+		if baseMetricName, suffix, useBaseMetricName, ok = stripComplexMetricSuffix(metricName); ok {
 			metadata, err = c.metadata.Get(ctx, job, instance, baseMetricName)
 			if err != nil {
 				return errors.Wrap(err, "get metadata")
+			}
+			if useBaseMetricName {
+				metricName = baseMetricName
 			}
 		}
 		if metadata == nil {

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -135,20 +135,20 @@ const (
 	metricSuffixTotal  = "_total"
 )
 
-func stripComplexMetricSuffix(name string) (prefix string, suffix string, useBaseMetricName bool, ok bool) {
+func stripComplexMetricSuffix(name string) (prefix string, suffix string, ok bool) {
 	if strings.HasSuffix(name, metricSuffixBucket) {
-		return name[:len(name)-len(metricSuffixBucket)], metricSuffixBucket, false, true
+		return name[:len(name)-len(metricSuffixBucket)], metricSuffixBucket, true
 	}
 	if strings.HasSuffix(name, metricSuffixCount) {
-		return name[:len(name)-len(metricSuffixCount)], metricSuffixCount, false, true
+		return name[:len(name)-len(metricSuffixCount)], metricSuffixCount, true
 	}
 	if strings.HasSuffix(name, metricSuffixSum) {
-		return name[:len(name)-len(metricSuffixSum)], metricSuffixSum, false, true
+		return name[:len(name)-len(metricSuffixSum)], metricSuffixSum, true
 	}
 	if strings.HasSuffix(name, metricSuffixTotal) {
-		return name[:len(name)-len(metricSuffixTotal)], metricSuffixTotal, true, true
+		return name[:len(name)-len(metricSuffixTotal)], metricSuffixTotal, true
 	}
-	return name, "", false, false
+	return name, "", false
 }
 
 const (

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -132,19 +132,23 @@ const (
 	metricSuffixBucket = "_bucket"
 	metricSuffixSum    = "_sum"
 	metricSuffixCount  = "_count"
+	metricSuffixTotal  = "_total"
 )
 
-func stripComplexMetricSuffix(name string) (string, string, bool) {
+func stripComplexMetricSuffix(name string) (prefix string, suffix string, useBaseMetricName bool, ok bool) {
 	if strings.HasSuffix(name, metricSuffixBucket) {
-		return name[:len(name)-len(metricSuffixBucket)], metricSuffixBucket, true
+		return name[:len(name)-len(metricSuffixBucket)], metricSuffixBucket, false, true
 	}
 	if strings.HasSuffix(name, metricSuffixCount) {
-		return name[:len(name)-len(metricSuffixCount)], metricSuffixCount, true
+		return name[:len(name)-len(metricSuffixCount)], metricSuffixCount, false, true
 	}
 	if strings.HasSuffix(name, metricSuffixSum) {
-		return name[:len(name)-len(metricSuffixSum)], metricSuffixSum, true
+		return name[:len(name)-len(metricSuffixSum)], metricSuffixSum, false, true
 	}
-	return name, "", false
+	if strings.HasSuffix(name, metricSuffixTotal) {
+		return name[:len(name)-len(metricSuffixTotal)], metricSuffixTotal, true, true
+	}
+	return name, "", false, false
 }
 
 const (

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -626,7 +626,8 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 		},
-		// Metrics with the _total suffix should be preserved if metadata can be found for the original metric name.
+		// Any counter metric with the _total suffix should be treated as normal if metadata
+		// can be found for the original metric name.
 		{
 			series: seriesMap{
 				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "1", "__name__", "metric1_total"),
@@ -670,7 +671,9 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 		},
-		// Metrics with the _total suffix should fail over to the metadata for the metric with the _total suffix removed.
+		// Any counter metric with the _total suffix should fail over to the metadata for
+		// the metric with the _total suffix removed while reporting the metric with the
+		// _total suffix removed in the metric name as well.
 		{
 			series: seriesMap{
 				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "1", "__name__", "metric1_total"),
@@ -709,6 +712,49 @@ func TestSampleBuilder(t *testing.T) {
 						},
 						Value: &monitoring_pb.TypedValue{
 							Value: &monitoring_pb.TypedValue_DoubleValue{2.5},
+						},
+					}},
+				},
+			},
+		},
+		// Any non-counter metric with the _total suffix should fail over to the metadata
+		// for the metric with the _total suffix removed while reporting the metric with
+		// the original name.
+		{
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "1", "__name__", "metric1_total"),
+			},
+			targets: targetMap{
+				"job1/instance1": &targets.Target{
+					Labels:           promlabels.FromStrings("job", "job1", "instance", "instance1"),
+					DiscoveredLabels: promlabels.FromStrings("__resource_a", "resource2_a"),
+				},
+			},
+			metadata: metadataMap{
+				"job1/instance1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
+			},
+			metricPrefix: "test.googleapis.com",
+			input: []tsdb.RefSample{
+				{Ref: 1, T: 3000, V: 8},
+			},
+			result: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type:   "resource2",
+						Labels: map[string]string{"resource_a": "resource2_a"},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "test.googleapis.com/metric1_total",
+						Labels: map[string]string{"a": "1"},
+					},
+					MetricKind: metric_pb.MetricDescriptor_GAUGE,
+					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							EndTime: &timestamp_pb.Timestamp{Seconds: 3},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DoubleValue{8},
 						},
 					}},
 				},

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -626,6 +626,88 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 		},
+		// Metrics with the _total suffix should be preserved if metadata can be found for the original metric name.
+		{
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "1", "__name__", "metric1_total"),
+			},
+			targets: targetMap{
+				"job1/instance1": &targets.Target{
+					Labels:           promlabels.FromStrings("job", "job1", "instance", "instance1"),
+					DiscoveredLabels: promlabels.FromStrings("__resource_a", "resource2_a"),
+				},
+			},
+			metadata: metadataMap{
+				"job1/instance1/metric1_total": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1_total"},
+			},
+			metricPrefix: "test.googleapis.com",
+			input: []tsdb.RefSample{
+				{Ref: 1, T: 1000, V: 200},
+			},
+			result: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type:   "resource2",
+						Labels: map[string]string{"resource_a": "resource2_a"},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "test.googleapis.com/metric1_total",
+						Labels: map[string]string{"a": "1"},
+					},
+					MetricKind: metric_pb.MetricDescriptor_GAUGE,
+					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DoubleValue{200},
+						},
+					}},
+				},
+			},
+		},
+		// Metrics with the _total suffix should fail over to the metadata for the metric with the _total suffix removed.
+		{
+			series: seriesMap{
+				1: labels.FromStrings("job", "job1", "instance", "instance1", "a", "1", "__name__", "metric1_total"),
+			},
+			targets: targetMap{
+				"job1/instance1": &targets.Target{
+					Labels:           promlabels.FromStrings("job", "job1", "instance", "instance1"),
+					DiscoveredLabels: promlabels.FromStrings("__resource_a", "resource2_a"),
+				},
+			},
+			metadata: metadataMap{
+				"job1/instance1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
+			},
+			metricPrefix: "test.googleapis.com",
+			input: []tsdb.RefSample{
+				{Ref: 1, T: 1000, V: 200},
+			},
+			result: []*monitoring_pb.TimeSeries{
+				{
+					Resource: &monitoredres_pb.MonitoredResource{
+						Type:   "resource2",
+						Labels: map[string]string{"resource_a": "resource2_a"},
+					},
+					Metric: &metric_pb.Metric{
+						Type:   "test.googleapis.com/metric1",
+						Labels: map[string]string{"a": "1"},
+					},
+					MetricKind: metric_pb.MetricDescriptor_GAUGE,
+					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
+					Points: []*monitoring_pb.Point{{
+						Interval: &monitoring_pb.TimeInterval{
+							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
+						},
+						Value: &monitoring_pb.TypedValue{
+							Value: &monitoring_pb.TypedValue_DoubleValue{200},
+						},
+					}},
+				},
+			},
+		},
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -638,13 +638,15 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 			metadata: metadataMap{
-				"job1/instance1/metric1_total": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1_total"},
+				"job1/instance1/metric1_total": &scrape.MetricMetadata{Type: textparse.MetricTypeCounter, Metric: "metric1_total"},
 			},
 			metricPrefix: "test.googleapis.com",
 			input: []tsdb.RefSample{
-				{Ref: 1, T: 1000, V: 200},
+				{Ref: 1, T: 2000, V: 5.5},
+				{Ref: 1, T: 3000, V: 8},
 			},
 			result: []*monitoring_pb.TimeSeries{
+				nil, // Skipped by reset timestamp handling.
 				{
 					Resource: &monitoredres_pb.MonitoredResource{
 						Type:   "resource2",
@@ -654,14 +656,15 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "test.googleapis.com/metric1_total",
 						Labels: map[string]string{"a": "1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
+					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
 					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
-							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
+							StartTime: &timestamp_pb.Timestamp{Seconds: 2},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 3},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{200},
+							Value: &monitoring_pb.TypedValue_DoubleValue{2.5},
 						},
 					}},
 				},
@@ -679,13 +682,15 @@ func TestSampleBuilder(t *testing.T) {
 				},
 			},
 			metadata: metadataMap{
-				"job1/instance1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeGauge, Metric: "metric1"},
+				"job1/instance1/metric1": &scrape.MetricMetadata{Type: textparse.MetricTypeCounter, Metric: "metric1"},
 			},
 			metricPrefix: "test.googleapis.com",
 			input: []tsdb.RefSample{
-				{Ref: 1, T: 1000, V: 200},
+				{Ref: 1, T: 2000, V: 5.5},
+				{Ref: 1, T: 3000, V: 8},
 			},
 			result: []*monitoring_pb.TimeSeries{
+				nil, // Skipped by reset timestamp handling.
 				{
 					Resource: &monitoredres_pb.MonitoredResource{
 						Type:   "resource2",
@@ -695,14 +700,15 @@ func TestSampleBuilder(t *testing.T) {
 						Type:   "test.googleapis.com/metric1",
 						Labels: map[string]string{"a": "1"},
 					},
-					MetricKind: metric_pb.MetricDescriptor_GAUGE,
+					MetricKind: metric_pb.MetricDescriptor_CUMULATIVE,
 					ValueType:  metric_pb.MetricDescriptor_DOUBLE,
 					Points: []*monitoring_pb.Point{{
 						Interval: &monitoring_pb.TimeInterval{
-							EndTime: &timestamp_pb.Timestamp{Seconds: 1},
+							StartTime: &timestamp_pb.Timestamp{Seconds: 2},
+							EndTime:   &timestamp_pb.Timestamp{Seconds: 3},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{200},
+							Value: &monitoring_pb.TypedValue_DoubleValue{2.5},
 						},
 					}},
 				},


### PR DESCRIPTION
This change should resolve the bug discovered in #144 where metrics introduced in Python3 client librarie have adopted the new standard for tracking counter creation time with `_total` and `_created` suffixes.