### PR TITLE
Comply IPv6 url with RFC2732.

### DIFF
--- a/stackdriver/client_test.go
+++ b/stackdriver/client_test.go
@@ -179,7 +179,7 @@ func TestResolver(t *testing.T) {
 		expectedTarget := fmt.Sprintf("%s:///%s",
 			c.resolver.Scheme(), test.expectedAddress)
 		if requestedTarget != expectedTarget {
-			t.Errorf("ERROR: get target as %s, want %s",
+			t.Errorf("ERROR: got target as %s, want %s",
 				requestedTarget, expectedTarget)
 		}
 	}


### PR DESCRIPTION
Literal IPv6 should be enclosed in "[" and "]" in URL. See details in
https://www.ietf.org/rfc/rfc2732.txt.