### PR TITLE
Update Compatibility chart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ The matrix below lists the versions of Prometheus Server and other dependencies 
 | **0.2.x**       |          ✓          |          ✗          |          ✗          |
 | **0.3.x**       |          ✓          |          ✗          |          ✓          |
 | **0.4.x**       |          ?          |          ✗          |          ✓          |
+| **0.5.x**       |          ?          |          ✗          |          ✓          |
 
 - ✓: Verified as compatible.
 - ✗: Verified as incompatible.


### PR DESCRIPTION
Confirmed that 0.5.0 is compatible with 2.6.x after running [e2e test](https://github.com/Stackdriver/stackdriver-prometheus-e2e).