### PR TITLE
Csh cloudbuilder

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,11 +12,13 @@ steps:
   args: [
     'build',
     '-t', 'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${TAG_NAME}${BRANCH_NAME}',
+    '-t', 'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${TAG_NAME}${BRANCH_NAME}-${SHORT_SHA}',
     '-t', 'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${SHORT_SHA}',
     '.'
   ]
 images: [
   'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${TAG_NAME}${BRANCH_NAME}',
+  'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${TAG_NAME}${BRANCH_NAME}-${SHORT_SHA}',
   'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${SHORT_SHA}'
 ]
 options:

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,24 @@
+steps:
+- name: 'mirror.gcr.io/library/golang'
+  entrypoint: make
+  args: ['format']
+- name: 'mirror.gcr.io/library/golang'
+  entrypoint: make
+  args: ['build']
+- name: 'mirror.gcr.io/library/golang'
+  entrypoint: make
+  args: ['test']
+- name: docker
+  args: [
+    'build',
+    '-t', 'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${TAG_NAME}${BRANCH_NAME}',
+    '-t', 'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${SHORT_SHA}',
+    '.'
+  ]
+images: [
+  'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${TAG_NAME}${BRANCH_NAME}',
+  'gcr.io/$PROJECT_ID/stackdriver-prometheus-sidecar:${SHORT_SHA}'
+]
+options:
+ diskSizeGb: 200
+ machineType: 'N1_HIGHCPU_8'


### PR DESCRIPTION
Add a `cloudbuild.yaml` file for building the stackdriver-prometheus-sidecar binary and docker image with Google's Cloud Build service.