### PR TITLE
Removed obsolete comment.

### DIFF
--- a/stackdriver/queue_manager.go
+++ b/stackdriver/queue_manager.go
@@ -202,8 +202,7 @@ func NewQueueManager(logger log.Logger, cfg config.QueueConfig, clientFactory St
 	return t, nil
 }
 
-// Append queues a sample to be sent to the remote storage. It drops the
-// sample on the floor if the queue is full.
+// Append queues a sample to be sent to the Stackdriver API.
 // Always returns nil.
 func (t *QueueManager) Append(hash uint64, sample *monitoring_pb.TimeSeries) error {
 	queueLength.WithLabelValues(t.queueName).Inc()


### PR DESCRIPTION
The intended behavior was always to block. Dropping data was one of the problems with the original remote storage that we intended to solve with our integration design (go/stackdriver-prometheus-ext). This code was adapted from upstream Prometheus server, and the comment came with the original code.