### PR TITLE
Change git.apache.org to github.com/apache.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	k8s.io/utils v0.0.0-20190801114015-581e00157fb1 // indirect
 )
 
-// TODO(qingling128): Change git.apache.org to github.com/apache/thrift in go.sum
-// instead once all our dependencies move off git.apache.org.
+// TODO(qingling128): Change git.apache.org to github.com/apache/thrift in
+// go.sum instead once all our dependencies move off git.apache.org (e.g. grep
+// no longer shows git.apache.org in the vendor folder).
 replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0

--- a/go.mod
+++ b/go.mod
@@ -61,3 +61,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20190722073852-5e22f3d471e6 // indirect
 	k8s.io/utils v0.0.0-20190801114015-581e00157fb1 // indirect
 )
+
+// TODO(qingling128): Change git.apache.org to github.com/apache/thrift in go.sum
+// instead once all our dependencies move off git.apache.org.
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0


### PR DESCRIPTION
Apache seem to be moving towards using GitHub: https://blogs.apache.org/foundation/entry/the-apache-software-foundation-expands


```
The Apache® Software Foundation (ASF), the all-volunteer developers, stewards, and incubators of more than 350 Open Source projects and initiatives, announced today it has completed its Infrastructure support expansion by migrating its Git service to GitHub.
```