### PR TITLE
Reformat the Compatibility table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,12 @@ When using Counter Aggregator you would usually want to configure a restrictive 
 
 The matrix below lists the versions of Prometheus Server and other dependencies that have been qualified to work with releases of `stackdriver-prometheus-sidecar`. If the matrix does not list whether they are compatible, please assume they are not verified yet. Feel free to contribute to the matrix if you have run the end-to-end test between a version of `stackdriver-prometheus-sidecar` and Prometheus server. 
 
-| sidecar version | **Prometheus 2.4.3**| **Prometheus 2.5.x**| **Prometheus 2.6.x**|**Prometheus 2.7+  **|
-|-----------------|---------------------|---------------------|---------------------|---------------------|
-| **0.2.x**       |          ✓          |          ✗          |          ✗          |          ?          |
-| **0.3.x**       |          ✓          |          ✗          |          ✓          |          ?          |
-| **0.4.x**       |          ?          |          ✗          |          ✓          |          ?          |
-| **0.5.x**       |          ?          |          ✗          |          ✓          |          ?          |
+| sidecar version | **Prometheus 2.4.3** | **Prometheus 2.5.x** | **Prometheus 2.6.x** | **Prometheus 2.7+** |
+|-----------------|----------------------|----------------------|----------------------|---------------------|
+| **0.2.x**       |          ✓           |          ✗           |          ✗           |          ?          |
+| **0.3.x**       |          ✓           |          ✗           |          ✓           |          ?          |
+| **0.4.x**       |          ?           |          ✗           |          ✓           |          ?          |
+| **0.5.x**       |          ?           |          ✗           |          ✓           |          ?          |
 
 - ✓: Verified as compatible.
 - ✗: Verified as incompatible.


### PR DESCRIPTION
The existing table will render table header on Prometheus 2.7 incorrectly as it will show as

** Prometheus 2.7 **

 This change should fix the format.

I also ensure spaces before and after the header text.