### PR TITLE
Remove unused metric dropped_samples_total.

### DIFF
--- a/stackdriver/queue_manager.go
+++ b/stackdriver/queue_manager.go
@@ -63,15 +63,6 @@ var (
 		},
 		[]string{queue},
 	)
-	droppedSamplesTotal = prometheus.NewCounterVec(
-		prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "dropped_samples_total",
-			Help:      "Total number of samples which were dropped due to the queue being full.",
-		},
-		[]string{queue},
-	)
 	sentBatchDuration = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -114,7 +105,6 @@ var (
 func init() {
 	prometheus.MustRegister(succeededSamplesTotal)
 	prometheus.MustRegister(failedSamplesTotal)
-	prometheus.MustRegister(droppedSamplesTotal)
 	prometheus.MustRegister(sentBatchDuration)
 	prometheus.MustRegister(queueLength)
 	prometheus.MustRegister(queueCapacity)
@@ -197,7 +187,6 @@ func NewQueueManager(logger log.Logger, cfg config.QueueConfig, clientFactory St
 	sentBatchDuration.WithLabelValues(t.queueName)
 	succeededSamplesTotal.WithLabelValues(t.queueName)
 	failedSamplesTotal.WithLabelValues(t.queueName)
-	droppedSamplesTotal.WithLabelValues(t.queueName)
 
 	return t, nil
 }


### PR DESCRIPTION
Same content as https://github.com/Stackdriver/stackdriver-prometheus-sidecar/pull/167, but using a regular branch instead of a fork.