### PR TITLE
Change base image to distroless and run container as root.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM        quay.io/prometheus/busybox:latest
+FROM  gcr.io/distroless/static:latest
 LABEL maintainer "Stackdriver Engineering <engineering@stackdriver.com>"
 
 COPY stackdriver-prometheus-sidecar         /bin/stackdriver-prometheus-sidecar
 COPY cmd/stackdriver-prometheus-sidecar/statusz-tmpl.html /statusz-tmpl.html
 
-USER       nobody
 EXPOSE     9091
 ENTRYPOINT [ "/bin/stackdriver-prometheus-sidecar" ]


### PR DESCRIPTION
Change base image to distroless because busybox violates internal security requirements.
Run container as root to work around k8s issues (https://github.com/prometheus/prometheus/issues/3441#issuecomment-436259370) with PVC.