### PR TITLE
Fix Hash Value For Prometheus Histogram Metrics.

### DIFF
--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -116,7 +116,7 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*mo
 		point.Value = &monitoring_pb.TypedValue{
 			Value: &monitoring_pb.TypedValue_DistributionValue{v},
 		}
-		return &ts, 0, samples, nil
+		return &ts, entry.hash, samples, nil
 
 	default:
 		return nil, 0, samples[1:], errors.Errorf("unexpected metric type %s", entry.metadata.Type)

--- a/retrieval/transform.go
+++ b/retrieval/transform.go
@@ -116,6 +116,9 @@ func (b *sampleBuilder) next(ctx context.Context, samples []tsdb.RefSample) (*mo
 		point.Value = &monitoring_pb.TypedValue{
 			Value: &monitoring_pb.TypedValue_DistributionValue{v},
 		}
+		if !b.series.updateSampleInterval(entry.hash, resetTimestamp, sample.T) {
+			return nil, 0, samples, nil
+		}
 		return &ts, entry.hash, samples, nil
 
 	default:


### PR DESCRIPTION
Through internal investigation, I observed that one of the queue length
is consistently high and blocked the whole queue manager. I identified
that there are large volume of points with hash value 0 tried to be
enqueued on to shard #0, which makes the sharding inbalance and the
sharded queue are constantly blocked by shard #0.

When Stackdriver Prometheus Sidecar tries to transform Prometheus
histogram metrics into Stackdriver timeseries with value type
distribution, it should return the hash values derived by series cache
rather than 0. This change fixes the undesired behavior.