### PR TITLE
Mark cred retrieval error as recoverable error.

### DIFF
--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -112,7 +112,7 @@ func (c *Client) getConnection(ctx context.Context) (*grpc.ClientConn, error) {
 	if useAuth {
 		rpcCreds, err := oauth.NewApplicationDefault(context.Background(), MonitoringWriteScope)
 		if err != nil {
-			return nil, err
+			return nil, recoverableError{err}
 		}
 		tlsCreds := credentials.NewTLS(&tls.Config{})
 		dopts = append(dopts,


### PR DESCRIPTION
The Client should not drop the sample because the credential cannot be
retrieved. Once the credential is set correctly, client should try to
resend the samples.