### PR TITLE
Mark more grpc error codes as recoverable errors.

### DIFF
--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -180,7 +180,9 @@ func (c *Client) Store(req *monitoring.CreateTimeSeriesRequest) error {
 					return
 				}
 				switch status.Code() {
-				case codes.DeadlineExceeded, codes.Unavailable:
+				case codes.Canceled, codes.DeadlineExceeded,
+				     codes.PermissionDenied,
+				     codes.Unauthenticated, codes.Unavailable:
 					errors <- recoverableError{err}
 				default:
 					errors <- err

--- a/stackdriver/client_test.go
+++ b/stackdriver/client_test.go
@@ -82,11 +82,23 @@ func TestStoreErrorHandling(t *testing.T) {
 			recoverable: false,
 		},
 		{
-			status:      status.New(codes.Unavailable, longErrMessage),
+			status:      status.New(codes.Canceled, longErrMessage),
 			recoverable: true,
 		},
 		{
 			status:      status.New(codes.DeadlineExceeded, longErrMessage),
+			recoverable: true,
+		},
+		{
+			status:      status.New(codes.PermissionDenied, longErrMessage),
+			recoverable: true,
+		},
+		{
+			status:      status.New(codes.Unauthenticated, longErrMessage),
+			recoverable: true,
+		},
+		{
+			status:      status.New(codes.Unavailable, longErrMessage),
 			recoverable: true,
 		},
 	}


### PR DESCRIPTION
- When CANCELED is returned, the operation was cancelled. Mark the
  error as recoverable and allows the Client to resend the samples.
- When DEADLINE_EXCEEDED is returned, the operation might not be
  completed. Mark the error as recoverable and allows the Client to
  resend the samples.
- When PERMISSION_DENIED or UNAUTHENTICATED errors are returned, it's
  the errors are not caused by the samples - so we mark the errors as
  recoverable errors and allows the Client to resend the samples until
  the permission and authentication are fixed.