### PR TITLE
Document error handling for grpc codes.

### DIFF
--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -181,16 +181,11 @@ func (c *Client) Store(req *monitoring.CreateTimeSeriesRequest) error {
 				}
 				switch status.Code() {
 				// codes.DeadlineExceeded:
-				//   It is safe to recover and retry
-				//   for all cases of
-				//   google.monitoring.v3.MetricService.CreateTimeSeries.
-				//
-				//   On the client side, if the client is unable to
-				//   send the request to server, it's safe to retry
-				//   until the client can send the request to server.
-				//
-				//   On the server side, no sample is unrecoverable
-				//   permanently within the server side timeout.
+				//   It is safe to retry
+				//   google.monitoring.v3.MetricService.CreateTimeSeries
+				//   requests with backoff because QueueManager
+				//   enforces in-order write on a time series, which
+				//   is a requirement for Stackdriver Monitoring writes.
 				//
 				// codes.Unavailable:
 				//   The condition is most likely transient. It can

--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -180,6 +180,21 @@ func (c *Client) Store(req *monitoring.CreateTimeSeriesRequest) error {
 					return
 				}
 				switch status.Code() {
+				// codes.DeadlineExceeded:
+				//   It is safe to recover and retry
+				//   for all cases of
+				//   google.monitoring.v3.MetricService.CreateTimeSeries.
+				//
+				//   On the client side, if the client is unable to
+				//   send the request to server, it's safe to retry
+				//   until the client can send the request to server.
+				//
+				//   On the server side, no sample is unrecoverable
+				//   permanently within the server side timeout.
+				//
+				// codes.Unavailable:
+				//   The condition is most likely transient. It can
+				//   be corrected by retrying with a backoff.
 				case codes.DeadlineExceeded, codes.Unavailable:
 					errors <- recoverableError{err}
 				default:

--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -184,12 +184,12 @@ func (c *Client) Store(req *monitoring.CreateTimeSeriesRequest) error {
 				//   It is safe to retry
 				//   google.monitoring.v3.MetricService.CreateTimeSeries
 				//   requests with backoff because QueueManager
-				//   enforces in-order write on a time series, which
-				//   is a requirement for Stackdriver Monitoring writes.
+				//   enforces in-order writes on a time series, which
+				//   is a requirement for Stackdriver monitoring.
 				//
 				// codes.Unavailable:
-				//   The condition is most likely transient. It can
-				//   be corrected by retrying with a backoff.
+				//   The condition is most likely transient. The request can
+				//   be retried with backoff.
 				case codes.DeadlineExceeded, codes.Unavailable:
 					errors <- recoverableError{err}
 				default:


### PR DESCRIPTION
Document why making grpc codes DeadlineExceeded and Unavailable
as recoverable errors.