### PR TITLE
Fixed compilation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,4 @@ require (
 	k8s.io/utils v0.0.0-20190801114015-581e00157fb1 // indirect
 )
 
-// TODO(qingling128): Change git.apache.org to github.com/apache/thrift in
-// go.sum instead once all our dependencies move off git.apache.org (e.g. grep
-// no longer shows git.apache.org in the vendor folder).
-replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+go 1.13


### PR DESCRIPTION
The thrift alias was giving this error:
```
GO111MODULE=on go test  -mod=vendor ./...
?       github.com/Stackdriver/stackdriver-prometheus-sidecar/bench     [no test files]
compilation error :go: github.com/apache/thrift@v0.12.0 used for two different module paths (git.apache.or
g/thrift.git and github.com/apache/thrift)                                                               
 
FAIL    github.com/Stackdriver/stackdriver-prometheus-sidecar/cmd/stackdriver-prometheus-sidecar        0.
364s                                                                                                     
```