### PR TITLE
Avoid loading resources from the network on `make format`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test:
 	@echo ">> running all tests"
 	GO111MODULE=$(GO111MODULE) $(GO) test $(GOOPTS) $(pkgs)
 
-cover:
+cover: format
 	@echo ">> running all tests with coverage"
 	GO111MODULE=$(GO111MODULE) $(GO) test -coverprofile=coverage.out $(GOOPTS) $(pkgs)
 

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test:
 	@echo ">> running all tests"
 	GO111MODULE=$(GO111MODULE) $(GO) test $(GOOPTS) $(pkgs)
 
-cover: format
+cover:
 	@echo ">> running all tests with coverage"
 	GO111MODULE=$(GO111MODULE) $(GO) test -coverprofile=coverage.out $(GOOPTS) $(pkgs)
 
@@ -81,6 +81,7 @@ format:
 	@echo ">> formatting code"
 	# Replace gofmt call once we bump to a more recent Go that supports `-mod=vendor`, probably 1.14.
 	# GO111MODULE=$(GO111MODULE) $(GO) fmt $(GOOPTS) $(pkgs)
+	# Avoid formatting anything under vendor/.
 	$(GOFMT) -l -w $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 
 vet:

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ cover:
 
 format:
 	@echo ">> formatting code"
-	GO111MODULE=$(GO111MODULE) $(GO) fmt -mod=vendor $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) fmt $(GOOPTS) $(pkgs)
 
 vet:
 	@echo ">> vetting code"

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ cover:
 
 format:
 	@echo ">> formatting code"
-	GO111MODULE=$(GO111MODULE) $(GO) fmt $(pkgs)
+	GO111MODULE=$(GO111MODULE) $(GO) fmt -mod=vendor $(pkgs)
 
 vet:
 	@echo ">> vetting code"

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ format:
 	@echo ">> formatting code"
 	# Replace gofmt call once we bump to a more recent Go that supports `-mod=vendor`, probably 1.14.
 	# GO111MODULE=$(GO111MODULE) $(GO) fmt $(GOOPTS) $(pkgs)
-	@! $(GOFMT) -l -w $(shell find . -path ./vendor -prune -o -name '*.go' -print)
+	$(GOFMT) -l -w $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 
 vet:
 	@echo ">> vetting code"

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,9 @@ cover: format
 
 format:
 	@echo ">> formatting code"
-	GO111MODULE=$(GO111MODULE) $(GO) fmt $(GOOPTS) $(pkgs)
+	# Replace gofmt call once we bump to a more recent Go that supports `-mod=vendor`, probably 1.14.
+	# GO111MODULE=$(GO111MODULE) $(GO) fmt $(GOOPTS) $(pkgs)
+	@! $(GOFMT) -l -w $(shell find . -path ./vendor -prune -o -name '*.go' -print)
 
 vet:
 	@echo ">> vetting code"


### PR DESCRIPTION
This removes network loads until `go fmt` stops trying to download those resources. https://github.com/golang/go/issues/27841 has more information.