### PR TITLE
Avoid network fetches when running coverage.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,9 +134,9 @@ promu:
 	rm -r $(PROMU_TMP)
 
 $(FIRST_GOPATH)/bin/staticcheck:
-	GOOS= GOARCH= GO111MODULE=$(GO111MODULE) $(GO) get honnef.co/go/tools/cmd/staticcheck
+	GOOS= GOARCH= GO111MODULE=off $(GO) get honnef.co/go/tools/cmd/staticcheck
 
 $(FIRST_GOPATH)/bin/goveralls:
-	GOOS= GOARCH= GO111MODULE=$(GO111MODULE) $(GO) get github.com/mattn/goveralls
+	GOOS= GOARCH= GO111MODULE=off $(GO) get github.com/mattn/goveralls
 
 .PHONY: all style deps format build test vet assets tarball docker promu staticcheck $(FIRST_GOPATH)/bin/staticcheck goveralls $(FIRST_GOPATH)/bin/goveralls

--- a/Makefile
+++ b/Makefile
@@ -134,9 +134,9 @@ promu:
 	rm -r $(PROMU_TMP)
 
 $(FIRST_GOPATH)/bin/staticcheck:
-	GOOS= GOARCH= $(GO) get honnef.co/go/tools/cmd/staticcheck
+	GOOS= GOARCH= GO111MODULE=$(GO111MODULE) $(GO) get honnef.co/go/tools/cmd/staticcheck
 
 $(FIRST_GOPATH)/bin/goveralls:
-	GOOS= GOARCH= $(GO) get github.com/mattn/goveralls
+	GOOS= GOARCH= GO111MODULE=$(GO111MODULE) $(GO) get github.com/mattn/goveralls
 
 .PHONY: all style deps format build test vet assets tarball docker promu staticcheck $(FIRST_GOPATH)/bin/staticcheck goveralls $(FIRST_GOPATH)/bin/goveralls

--- a/Makefile
+++ b/Makefile
@@ -134,9 +134,9 @@ promu:
 	rm -r $(PROMU_TMP)
 
 $(FIRST_GOPATH)/bin/staticcheck:
-	GOOS= GOARCH= $(GO) get -u honnef.co/go/tools/cmd/staticcheck
+	GOOS= GOARCH= $(GO) get honnef.co/go/tools/cmd/staticcheck
 
 $(FIRST_GOPATH)/bin/goveralls:
-	GOOS= GOARCH= $(GO) get -u github.com/mattn/goveralls
+	GOOS= GOARCH= $(GO) get github.com/mattn/goveralls
 
 .PHONY: all style deps format build test vet assets tarball docker promu staticcheck $(FIRST_GOPATH)/bin/staticcheck goveralls $(FIRST_GOPATH)/bin/goveralls


### PR DESCRIPTION
This is caused by a combination of the `GO111MODULES=on` flag and the `-u` flag to `go get`, which causes it to download many dependencies unnecessarily. _Magic_ fix.