### PR TITLE
Publish standard grpc.io metrics.

### DIFF
--- a/cmd/stackdriver-prometheus-sidecar/main.go
+++ b/cmd/stackdriver-prometheus-sidecar/main.go
@@ -104,11 +104,7 @@ func init() {
 		panic(err)
 	}
 	if err := view.Register(
-		ocgrpc.ClientSentBytesPerRPCView,
-		ocgrpc.ClientReceivedBytesPerRPCView,
-		ocgrpc.ClientRoundtripLatencyView,
-		ocgrpc.ClientCompletedRPCsView,
-		ocgrpc.ClientServerLatencyView,
+		ocgrpc.DefaultClientViews...
 	); err != nil {
 		panic(err)
 	}

--- a/cmd/stackdriver-prometheus-sidecar/main.go
+++ b/cmd/stackdriver-prometheus-sidecar/main.go
@@ -104,41 +104,11 @@ func init() {
 		panic(err)
 	}
 	if err := view.Register(
-		&view.View{
-			Measure:     ocgrpc.ClientSentBytesPerRPC,
-			Name:        "grpc.io/client/sent_bytes_per_rpc",
-			Description: "Distribution of bytes sent per RPC, by method.",
-			TagKeys:     []tag.Key{ocgrpc.KeyClientMethod, ocgrpc.KeyClientStatus},
-			Aggregation: sizeDistribution,
-		},
-		&view.View{
-			Measure:     ocgrpc.ClientReceivedBytesPerRPC,
-			Name:        "grpc.io/client/received_bytes_per_rpc",
-			Description: "Distribution of bytes received per RPC, by method.",
-			TagKeys:     []tag.Key{ocgrpc.KeyClientMethod, ocgrpc.KeyClientStatus},
-			Aggregation: sizeDistribution,
-		},
-		&view.View{
-			Measure:     ocgrpc.ClientRoundtripLatency,
-			Name:        "grpc.io/client/roundtrip_latency",
-			Description: "Distribution of round-trip latency, by method.",
-			TagKeys:     []tag.Key{ocgrpc.KeyClientMethod, ocgrpc.KeyClientStatus},
-			Aggregation: latencyDistribution,
-		},
-		&view.View{
-			Measure:     ocgrpc.ClientRoundtripLatency,
-			Name:        "grpc.io/client/completed_rpcs",
-			Description: "Count of RPCs by method and status.",
-			TagKeys:     []tag.Key{ocgrpc.KeyClientMethod, ocgrpc.KeyClientStatus},
-			Aggregation: view.Count(),
-		},
-		&view.View{
-			Measure:     ocgrpc.ClientServerLatency,
-			Name:        "grpc.io/client/server_latency",
-			Description: "Distribution of server latency as viewed by client, by method.",
-			TagKeys:     []tag.Key{ocgrpc.KeyClientMethod, ocgrpc.KeyClientStatus},
-			Aggregation: latencyDistribution,
-		},
+		ocgrpc.ClientSentBytesPerRPCView,
+		ocgrpc.ClientReceivedBytesPerRPCView,
+		ocgrpc.ClientRoundtripLatencyView,
+		ocgrpc.ClientCompletedRPCsView,
+		ocgrpc.ClientServerLatencyView,
 	); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
We were publishing a different version with an extra label, but had kept the upstream name of the metrics. This makes querying this metric across different components harder (or impossible).

This drops the grpc_client_status label from most metrics, but it shouldn't be a big loss, since metrics like request size are rarely correlated with an error.