### PR TITLE
Moving var statuszTmpl to func ServeHTTP

### DIFF
--- a/cmd/stackdriver-prometheus-sidecar/statusz.go
+++ b/cmd/stackdriver-prometheus-sidecar/statusz.go
@@ -27,7 +27,6 @@ import (
 
 var (
 	serverStart = time.Now()
-	statuszTmpl = template.Must(template.ParseFiles("statusz-tmpl.html"))
 )
 
 type statuszHandler struct {
@@ -79,7 +78,8 @@ func (h *statuszHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	data.GKEInfo.ClusterName = h.cfg.KubernetesLabels.ClusterName
 
 	data.Config = h.cfg
-
+	
+        var statuszTmpl = template.Must(template.ParseFiles("statusz-tmpl.html"))
 	if err := statuszTmpl.Execute(w, data); err != nil {
 		level.Error(h.logger).Log("msg", "couldn't execute template", "err", err)
 	}


### PR DESCRIPTION
When trying to run  stackdriver-prometheus-sidecar --help ,I get error  panic: open statusz-tmpl.html: no such file or directory. Moving the intialization of the statuszTmpl to func ServeHTTP which allows the use of --help