### PR TITLE
Update apps/v1beta2 to apps/v1 for GKE 1.16 compatibility.

### DIFF
--- a/kube/full/kube-state-metrics.yaml
+++ b/kube/full/kube-state-metrics.yaml
@@ -140,7 +140,7 @@ spec:
   selector:
     app: kube-state-metrics
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/kube/full/node-exporter.yaml
+++ b/kube/full/node-exporter.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/kube/full/prometheus.yaml
+++ b/kube/full/prometheus.yaml
@@ -73,7 +73,7 @@ spec:
     prometheus: k8s
   sessionAffinity: None
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: prometheus-k8s


### PR DESCRIPTION
GKE 1.16 release no longer serves DaemonSet and Deployment in the apps/v1beta2 API version (see [release notes](https://cloud.google.com/kubernetes-engine/docs/release-notes)).

Fixes #230.