### PR TITLE
Initialize the labels map in the response.

### DIFF
--- a/vendor/contrib.go.opencensus.io/exporter/stackdriver/stackdriver.go
+++ b/vendor/contrib.go.opencensus.io/exporter/stackdriver/stackdriver.go
@@ -338,6 +338,9 @@ func NewExporter(o Options) (*Exporter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("stackdriver: detect resource: %s", err)
 		}
+		if res.Labels == nil {
+			res.Labels = make(map[string]string)
+		}
 		// Populate internal resource labels for defaulting project_id, location, and
 		// generic resource labels of applicable monitored resources.
 		res.Labels[stackdriverProjectID] = o.ProjectID


### PR DESCRIPTION
Fixes the following error when the `labels` is not initialized:

```
Container logs:
level=info ts=2020-03-02T03:17:42.590Z caller=main.go:293 msg="Starting Stackdriver Prometheus sidecar" version="(version=0.7.3, branch=master, revision=2548e8a7b383adc9217afe8570247ea84e3ef2c0)"
level=info ts=2020-03-02T03:17:42.591Z caller=main.go:294 build_context="(go=go1.12, user=kbuilder@kokoro-gcp-ubuntu-prod-40088225, date=20200206-15:24:17)"
level=info ts=2020-03-02T03:17:42.591Z caller=main.go:295 host_details="(Linux 4.14.138+ #1 SMP Tue Sep 3 02:58:08 PDT 2019 x86_64 apigee-metrics-v111-fd6fj (none))"
level=info ts=2020-03-02T03:17:42.592Z caller=main.go:296 fd_limits="(soft=1048576, hard=1048576)"
panic: assignment to entry in nil map
```

Labels can be optionally extracted from OC_RESOURCE_TYPE and OC_RESOURCE_LABELS env vars (https://github.com/census-instrumentation/opencensus-go/blob/1901b56b9515b0c34f5d25a5bce982dfc543d64b/resource/resource.go#L30). In case those envs are not set, labels will not be initialized: https://github.com/census-instrumentation/opencensus-go/blob/1901b56b9515b0c34f5d25a5bce982dfc543d64b/resource/resource.go#L98

For the case here, we are in fact sending metrics to Stackdriver. So OC_RESOURCE_TYPE and OC_RESOURCE_LABELS may not be needed. But we should init the Labels field.

I'll send an equivalent PR to the upstream repo as well.