### PR TITLE
Delete the replica sets from the old deployment when patching the deployment.

### DIFF
--- a/kube/patch.sh
+++ b/kube/patch.sh
@@ -37,3 +37,5 @@ spec:
         - name: ${DATA_VOLUME}
           mountPath: ${DATA_DIR}
 "
+# Delete the replica sets from the old deployment.
+kubectl -n "${KUBE_NAMESPACE}" get rs | grep "$2-" | awk '{print $1}' | xargs kubectl delete -n "${KUBE_NAMESPACE}" rs

--- a/kube/patch.sh
+++ b/kube/patch.sh
@@ -5,7 +5,7 @@ set -u
 
 CLEAN_UP_ORPHANED_REPLICA_SETS='--clean-up-orphaned-replica-sets'
 usage() {
-  echo -e "Usage: $0 <deployment|statefulset> <name> <${CLEAN_UP_ORPHANED_REPLICA_SETS}>\n"
+  echo -e "Usage: $0 <deployment|statefulset> <name> [${CLEAN_UP_ORPHANED_REPLICA_SETS}]\n"
 }
 
 if [  $# -le 1 ]; then

--- a/kube/patch.sh
+++ b/kube/patch.sh
@@ -3,14 +3,17 @@
 set -e
 set -u
 
+CLEAN_UP_ORPHANED_REPLICA_SETS='--clean-up-orphaned-replica-sets'
 usage() {
-  echo -e "Usage: $0 <deployment|statefulset> <name>\n"
+  echo -e "Usage: $0 <deployment|statefulset> <name> <${CLEAN_UP_ORPHANED_REPLICA_SETS}>\n"
 }
 
 if [  $# -le 1 ]; then
   usage
   exit 1
 fi
+
+SHOULD_CLEAN_UP=${3:-}
 
 # Override to use a different Docker image name for the sidecar.
 export SIDECAR_IMAGE_NAME=${SIDECAR_IMAGE_NAME:-'gcr.io/stackdriver-prometheus/stackdriver-prometheus-sidecar'}
@@ -37,5 +40,7 @@ spec:
         - name: ${DATA_VOLUME}
           mountPath: ${DATA_DIR}
 "
-# Delete the replica sets from the old deployment.
-kubectl -n "${KUBE_NAMESPACE}" get rs | grep "$2-" | awk '{print $1}' | xargs kubectl delete -n "${KUBE_NAMESPACE}" rs
+if [[ "${SHOULD_CLEAN_UP}" == "${CLEAN_UP_ORPHANED_REPLICA_SETS}" ]]; then
+  # Delete the replica sets from the old deployment.
+  kubectl -n "${KUBE_NAMESPACE}" get rs | grep "$2-" | awk '{print $1}' | xargs kubectl delete -n "${KUBE_NAMESPACE}" rs
+fi

--- a/kube/patch.sh
+++ b/kube/patch.sh
@@ -41,6 +41,9 @@ spec:
           mountPath: ${DATA_DIR}
 "
 if [[ "${SHOULD_CLEAN_UP}" == "${CLEAN_UP_ORPHANED_REPLICA_SETS}" ]]; then
-  # Delete the replica sets from the old deployment.
+  # Delete the replica sets from the old deployment. If the Prometheus Server is
+  # a deployment that does not have `revisionHistoryLimit` set to 0, this is
+  # useful to avoid PVC conflicts between the old replica set and the new one
+  # that prevents the pod from entering a RUNNING state.
   kubectl -n "${KUBE_NAMESPACE}" get rs | grep "$2-" | awk '{print $1}' | xargs kubectl delete -n "${KUBE_NAMESPACE}" rs
 fi


### PR DESCRIPTION
Work around the issue when PVC is still being held by the old pods from the old deployment's replica set when patching the deployment:

```
  Warning  FailedAttachVolume  7m8s                attachdetach-controller                                       Multi-Attach error for volume "pvc-dc041109-cb02-11ea-82bf-42010a8001b2" Volume is already used by pod(s) prometheus-server-77bc48c5cb-qh5gp
  Warning  FailedMount         34s (x3 over 5m7s)  kubelet, gke-lingshi-prom-sidecar-default-pool-e7c128e9-btnb  Unable to mount volumes for pod "prometheus-server-6df94f65d5-wjbkf_prometheus(e23e0c7c-cb02-11ea-82bf-42010a8001b2)": timeout expired waiting for volumes to attach or mount for pod "prometheus"/"prometheus-server-6df94f65d5-wjbkf". list of unmounted
volumes=[storage-volume]. list of unattached volumes=[config-volume storage-volume prometheus-server-token-8s9mr]
```

Another option is to set `.spec.revisionHistoryLimit` to 0 for this deployment so that orphaned replica set gets deleted right away, but I feel like that is a bit too aggressive. Open to other suggestions as well.