### PR TITLE
Serialize Monitoring API calls

### DIFF
--- a/stackdriver/queue_manager.go
+++ b/stackdriver/queue_manager.go
@@ -509,7 +509,13 @@ func (s *shardCollection) runShard(i int) {
 
 func (s *shardCollection) sendSamples(client StorageClient, samples []*monitoring_pb.TimeSeries) {
 	begin := time.Now()
-	s.sendSamplesWithBackoff(client, samples)
+	for i := 0; i < len(samples); i += MaxTimeseriesesPerRequest {
+		end := i + MaxTimeseriesesPerRequest
+		if end > len(samples) {
+			end = len(samples)
+		}
+		s.sendSamplesWithBackoff(client, samples[i:end])
+	}
 
 	// These counters are used to calculate the dynamic sharding, and as such
 	// should be maintained irrespective of success or failure.


### PR DESCRIPTION
Monitoring API calls of TimeSeries that have same hash should be serialize.

* Points of same time series must be sent in order
I got following errors from Monitoring API.
    ```
    rpc error: code = InvalidArgument desc = One or more TimeSeries could not be written: Points must be written in order. 
    One or more of the points specified had an older end time than the most recent point.: timeSeries[0-199]
    ```
* Returning recoverableError or not is non-deterministic
    Returning first error in errors currently. This may drop some Points failed by recoverable errors.
https://github.com/Stackdriver/stackdriver-prometheus-sidecar/blob/1361301230bcfc978864a8f4c718aba98bc07a3d/stackdriver/client.go#L245-L247