### PR TITLE
ResourceExhausted is a recoverableError

### DIFF
--- a/stackdriver/client.go
+++ b/stackdriver/client.go
@@ -232,7 +232,7 @@ func (c *Client) Store(req *monitoring.CreateTimeSeriesRequest) error {
 				// codes.Unavailable:
 				//   The condition is most likely transient. The request can
 				//   be retried with backoff.
-				case codes.DeadlineExceeded, codes.Unavailable:
+				case codes.DeadlineExceeded, codes.Unavailable, codes.ResourceExhausted:
 					errors <- recoverableError{err}
 				default:
 					errors <- err

--- a/stackdriver/client_test.go
+++ b/stackdriver/client_test.go
@@ -110,6 +110,10 @@ func TestStoreErrorHandling(t *testing.T) {
 			status:      status.New(codes.DeadlineExceeded, longErrMessage),
 			recoverable: true,
 		},
+		{
+			status:      status.New(codes.ResourceExhausted, longErrMessage),
+			recoverable: true,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
I think ResoueceExhausted error by exceeding quota should be a recoverableError.
We should introduce some rate limiter (may use this unused rateLimiter? ), but this PR doesn't include it.
https://github.com/Stackdriver/stackdriver-prometheus-sidecar/blob/1361301230bcfc978864a8f4c718aba98bc07a3d/stackdriver/queue_manager.go#L163