### PR TITLE
Fix reset handling by checking against previous value instead of reset value.

### DIFF
--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -106,7 +106,7 @@ type seriesCacheEntry struct {
 	hasReset bool
 
 	// The value and timestamp of the latest reset. The timestamp is when it
-	// occurred and the value is what it was reset to. resetValue will initially
+	// occurred, and the value is what it was reset to. resetValue will initially
 	// be the value of the first sample, and then 0 for every subsequent reset.
 	resetValue     float64
 	resetTimestamp int64

--- a/retrieval/series_cache.go
+++ b/retrieval/series_cache.go
@@ -100,13 +100,21 @@ type seriesCacheEntry struct {
 	suffix   string
 	hash     uint64
 
+	// Whether the series has been reset/initialized yet. This is false only for
+	// the first sample of a new series in the cache, which causes the initial
+	// "reset". After that, it is always true.
+	hasReset bool
+
+	// The value and timestamp of the latest reset. The timestamp is when it
+	// occurred and the value is what it was reset to. resetValue will initially
+	// be the value of the first sample, and then 0 for every subsequent reset.
+	resetValue     float64
+	resetTimestamp int64
+
 	// Value of the most recent point seen for the time series. If a new value is
 	// less than the previous, then the series has reset.
 	previousValue float64
 
-	hasReset       bool
-	resetValue     float64
-	resetTimestamp int64
 	// maxSegment indicates the maximum WAL segment index in which
 	// the series was first logged.
 	// By providing it as an upper bound, we can safely delete a series entry

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -128,7 +128,7 @@ func TestSampleBuilder(t *testing.T) {
 				{Ref: 2, T: 2000, V: 5.5},
 				{Ref: 2, T: 3000, V: 8},
 				{Ref: 2, T: 4000, V: 9},
-				{Ref: 2, T: 5000, V: 3},
+				{Ref: 2, T: 5000, V: 7},
 				{Ref: 1, T: 1000, V: 200},
 				{Ref: 3, T: 3000, V: 1},
 				{Ref: 4, T: 4000, V: 2},
@@ -184,7 +184,7 @@ func TestSampleBuilder(t *testing.T) {
 						},
 					}},
 				},
-				{ // 3
+				{ // 3: Reset series since sample's value is less than previous value.
 					Resource: &monitoredres_pb.MonitoredResource{
 						Type:   "resource2",
 						Labels: map[string]string{"resource_a": "resource2_a"},
@@ -201,7 +201,7 @@ func TestSampleBuilder(t *testing.T) {
 							EndTime:   &timestamp_pb.Timestamp{Seconds: 5},
 						},
 						Value: &monitoring_pb.TypedValue{
-							Value: &monitoring_pb.TypedValue_DoubleValue{3},
+							Value: &monitoring_pb.TypedValue_DoubleValue{7},
 						},
 					}},
 				},


### PR DESCRIPTION
There's been a bug in reset handling (since inception) that detects a reset by checking if the current value is less than the initial/reset value, when it should be detecting drops by comparing against the previous value instead. For example, if a series receives values `4->10->6`, the existing code will not detect a reset when the value drops from `10` to `6` (even though it should), because `6` </ `4`. It would only detect a reset if the data were e.g. `4->10->3`, because `3`<`4`.

Further, this meant that the sidecar could allow at most one reset per time series (so long as it stayed in the cache), because after one reset, the baseline `resetValue` was [set to `0`](https://github.com/Stackdriver/stackdriver-prometheus-sidecar/blob/1361301230bcfc978864a8f4c718aba98bc07a3d/retrieval/series_cache.go#L308), and that was what [all subsequent values were compared against](https://github.com/Stackdriver/stackdriver-prometheus-sidecar/blob/1361301230bcfc978864a8f4c718aba98bc07a3d/retrieval/series_cache.go#L303) to identify resets. Since [Prometheus counters can't be negative](https://prometheus.io/docs/concepts/metric_types/#counter), no additional resets could occur (0 </ 0).

---
Related bugs (internal access only):
- http://b/172686457
- http://b/174756278
- http://b/172843713