### PR TITLE
Bash shebang needed due to [[ and ]] in if statement.

### DIFF
--- a/kube/patch.sh
+++ b/kube/patch.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 set -u


### PR DESCRIPTION
Make patch.sh script work on ubuntu.

/bin/sh is usually not soft-linked to bash on ubuntu, as it is on debian. I.e. the shebang should reflect the actual shell required by the script.