### PR TITLE
Add metric label filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,20 @@ The flag may be repeated to provide several sets of filters, in which case the m
 
 #### File
 
-The sidecar can also be provided with a configuration file. It allows to define static metric renames and to overwrite metric metadata which is usually provided by Prometheus. A configuration file should not be required for the majority of users.
+The sidecar can also be provided with a configuration file. It allows to define static metric renames, filter metric labels and to overwrite metric metadata which is usually provided by Prometheus. A configuration file should not be required for the majority of users.
 
 ```yaml
 metric_renames:
   - from: original_metric_name
     to: new_metric_name
+# - ...
+
+metric_label_filters:
+  - metric: "^too_many_labels.*"
+    allow:
+      - important_label
+      - other_important_label
+      - ...
 # - ...
 
 static_metadata:
@@ -83,6 +91,7 @@ static_metadata:
 # - ...
 ```
 
+  * The `metric_label_filters` accept regular expressions for `metric` names and a list of label names to `allow` for matching metrics.
   * All `static_metadata` entries must have `type` specified. This specifies the Stackdriver metric type and overrides the metric type chosen by the Prometheus client.
   * If `value_type` is specified, it will override the default value type for counters and gauges. All Prometheus metrics have a default type of double.
 

--- a/retrieval/manager.go
+++ b/retrieval/manager.go
@@ -82,6 +82,7 @@ func NewPrometheusReader(
 	tailer *tail.Tailer,
 	filtersets [][]*labels.Matcher,
 	metricRenames map[string]string,
+	labelFilters []LabelFilter,
 	targetGetter TargetGetter,
 	metadataGetter MetadataGetter,
 	appender Appender,
@@ -102,6 +103,7 @@ func NewPrometheusReader(
 		metadataGetter:       metadataGetter,
 		progressSaveInterval: time.Minute,
 		metricRenames:        metricRenames,
+		labelFilters:         labelFilters,
 		metricsPrefix:        metricsPrefix,
 		useGkeResource:       useGkeResource,
 		counterAggregator:    counterAggregator,
@@ -114,6 +116,7 @@ type PrometheusReader struct {
 	tailer               *tail.Tailer
 	filtersets           [][]*labels.Matcher
 	metricRenames        map[string]string
+	labelFilters         []LabelFilter
 	targetGetter         TargetGetter
 	metadataGetter       MetadataGetter
 	appender             Appender
@@ -157,6 +160,7 @@ func (r *PrometheusReader) Run(ctx context.Context, startOffset int) error {
 		r.walDirectory,
 		r.filtersets,
 		r.metricRenames,
+		r.labelFilters,
 		r.targetGetter,
 		r.metadataGetter,
 		ResourceMappings,

--- a/retrieval/manager_test.go
+++ b/retrieval/manager_test.go
@@ -86,7 +86,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	aggr, _ := NewCounterAggregator(log.NewNopLogger(), new(CounterAggregatorConfig))
-	r := NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, &nopAppender{}, "", false, aggr)
+	r := NewPrometheusReader(nil, dir, tailer, nil, nil, nil, targetMap, metadataMap, &nopAppender{}, "", false, aggr)
 	r.progressSaveInterval = 200 * time.Millisecond
 
 	// Populate sample data
@@ -143,7 +143,7 @@ func TestReader_Progress(t *testing.T) {
 	}
 
 	recorder := &nopAppender{}
-	r = NewPrometheusReader(nil, dir, tailer, nil, nil, targetMap, metadataMap, recorder, "", false, aggr)
+	r = NewPrometheusReader(nil, dir, tailer, nil, nil, nil, targetMap, metadataMap, recorder, "", false, aggr)
 	go r.Run(ctx, progressOffset)
 
 	// Wait for reader to process until the end.

--- a/retrieval/transform_test.go
+++ b/retrieval/transform_test.go
@@ -1145,7 +1145,7 @@ func TestSampleBuilder(t *testing.T) {
 		var hashes []uint64
 
 		aggr, _ := NewCounterAggregator(log.NewNopLogger(), new(CounterAggregatorConfig))
-		series := newSeriesCache(nil, "", nil, nil, c.targets, c.metadata, resourceMaps, c.metricPrefix, false, aggr)
+		series := newSeriesCache(nil, "", nil, nil, nil, c.targets, c.metadata, resourceMaps, c.metricPrefix, false, aggr)
 		for ref, s := range c.series {
 			series.set(ctx, ref, s, 0)
 		}


### PR DESCRIPTION
Adds a new configuration file setting `metric_label_filters` to allow importing metrics that would otherwise be silently dropped for `too many labels`.

Addresses #278.