### PR TITLE
Backport corrupted WAL error fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.4
 	github.com/Azure/azure-sdk-for-go v36.2.0+incompatible // indirect
-        github.com/Azure/go-autorest v13.3.0+incompatible // indirect
+	github.com/Azure/go-autorest v13.3.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.2.0 // indirect
@@ -48,6 +48,7 @@ require (
 	github.com/samuel/go-zookeeper v0.0.0-20190801204459-3c104360edc8 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.4.0
 	go.opencensus.io v0.22.4
 	golang.org/x/crypto v0.0.0-20191128160524-b544559bb6d1 // indirect
 	golang.org/x/net v0.0.0-20191126235420-ef20fe5d7933 // indirect

--- a/tail/tail.go
+++ b/tail/tail.go
@@ -207,6 +207,9 @@ func (t *Tailer) Read(b []byte) (int, error) {
 	}
 }
 
+// openSegment finds a WAL segment with a name that parses to n. This
+// way we do not need to know how wide the segment filename is (i.e.,
+// how many zeros to pad with).
 func openSegment(dir string, n int) (io.ReadCloser, error) {
 	files, err := fileutil.ReadDir(dir)
 	if err != nil {
@@ -214,11 +217,8 @@ func openSegment(dir string, n int) (io.ReadCloser, error) {
 	}
 	for _, fn := range files {
 		k, err := strconv.Atoi(fn)
-		if err != nil || k < n {
+		if err != nil || k != n {
 			continue
-		}
-		if k > n {
-			return nil, errors.Errorf("next segment %d too high, expected %d", n, k)
 		}
 		return wal.OpenReadSegment(filepath.Join(dir, fn))
 	}


### PR DESCRIPTION
This PR introduces the fix added to [lightstep/opentelemetry-prometheus-sidecar here](https://github.com/lightstep/opentelemetry-prometheus-sidecar/pull/71).

All credit goes to @jmacd!

Closes https://github.com/Stackdriver/stackdriver-prometheus-sidecar/issues/268